### PR TITLE
Add Bitmap Cache V0

### DIFF
--- a/app/rust/src/api/api.rs
+++ b/app/rust/src/api/api.rs
@@ -68,9 +68,11 @@ pub fn render_map_overlay(
     map_renderer
         .get_or_insert_with(|| {
             let mut main_db = state.storage.main_db.lock().unwrap();
+            // lock cache as well
+            let mut cache_db = state.storage.cache_db.lock().unwrap();
             // TODO: error handling?
             let journey_bitmap =
-                merged_journey_manager::get_latest_including_ongoing(&mut main_db).unwrap();
+                merged_journey_manager::get_latest_including_ongoing(&mut main_db, &mut cache_db).unwrap();
             MapRenderer::new(journey_bitmap)
         })
         .maybe_render_map_overlay(zoom, left, top, right, bottom)

--- a/app/rust/src/api/api.rs
+++ b/app/rust/src/api/api.rs
@@ -72,7 +72,8 @@ pub fn render_map_overlay(
             let mut cache_db = state.storage.cache_db.lock().unwrap();
             // TODO: error handling?
             let journey_bitmap =
-                merged_journey_manager::get_latest_including_ongoing(&mut main_db, &mut cache_db).unwrap();
+                merged_journey_manager::get_latest_including_ongoing(&mut main_db, &mut cache_db)
+                    .unwrap();
             MapRenderer::new(journey_bitmap)
         })
         .maybe_render_map_overlay(zoom, left, top, right, bottom)

--- a/app/rust/src/cache_db.rs
+++ b/app/rust/src/cache_db.rs
@@ -1,0 +1,158 @@
+extern crate simplelog;
+use rusqlite::{Connection, OptionalExtension, Transaction};
+use anyhow::{Result, bail};
+use std::cmp::Ordering;
+use std::path::Path;
+use protobuf::Message;
+
+use crate::journey_data::JourneyData;
+use crate::journey_header::{JourneyHeader, JourneyKind, JourneyType};
+
+// Function to open the database and run migrations
+fn open_db_and_run_migration(
+    cache_dir: &str,
+    file_name: &str,
+    migrations: &Vec<&dyn Fn(&Transaction) -> Result<()>>,
+) -> Result<Connection> {
+    debug!("open and run migration for {}", file_name);
+    let mut conn = Connection::open(Path::new(cache_dir).join(file_name))?;
+    let tx = conn.transaction()?;
+    let create_db_metadata_sql = "
+        CREATE TABLE IF NOT EXISTS `db_metadata` (
+            `key`    TEXT NOT NULL,
+            `value`  TEXT,
+            PRIMARY KEY(`key`)
+        )";
+    tx.execute(create_db_metadata_sql, [])?;
+
+    let version_str: Option<String> = tx
+        .query_row(
+            "SELECT `value` FROM `db_metadata` WHERE key='version'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()?;
+
+    let version = match version_str {
+        None => 0,
+        Some(s) => s.parse()?,
+    };
+
+    let target_version = migrations.len();
+    debug!(
+        "current version = {}, target_version = {}",
+        version, target_version
+    );
+    match version.cmp(&target_version) {
+        Ordering::Equal => (),
+        Ordering::Less => {
+            for i in version..target_version {
+                info!("running migration for version: {}", i + 1);
+                let f = migrations.get(i).unwrap();
+                f(&tx)?;
+            }
+            tx.execute(
+                "INSERT OR REPLACE INTO `db_metadata` (key, value) VALUES (?1, ?2)",
+                ("version", target_version.to_string()),
+            )?;
+        }
+        Ordering::Greater => {
+            bail!(
+                "version too high: current version = {}, target_version = {}",
+                version,
+                target_version
+            );
+        }
+    }
+    tx.commit()?;
+    Ok(conn)
+}
+
+// Transaction wrapper
+pub struct Txn<'a> {
+    db_txn: rusqlite::Transaction<'a>,
+}
+
+impl Txn<'_> {
+    // Method to insert journey bitmap blob
+    pub fn insert_journey_bitmap_blob(
+        &self,
+        date_bytes: Vec<u8>,
+    ) -> Result<()> {
+        let sql = "INSERT INTO journey_cache (data) VALUES (?1);";
+        self.db_txn.execute(
+            sql,
+            &[&date_bytes],
+        )?;
+        Ok(())
+    }
+
+    // Method to get the last journey
+    pub fn get_journey(&self) -> Result<JourneyData> {
+        let mut query = self
+            .db_txn
+            .prepare("SELECT data FROM journey_cache ORDER BY id DESC LIMIT 1;")?;
+    
+        query.query_row((), |row| {
+            let type_ = row.get_ref(0)?.as_i64()?;
+            let f = || {
+                let data = row.get_ref(1)?.as_blob()?;
+                JourneyData::deserialize(data, JourneyType::Bitmap)
+            };
+            Ok(f())
+        })?
+    }
+    
+}
+
+// CacheDb structure
+pub struct CacheDb {
+    conn: Connection,
+}
+
+impl CacheDb {
+    // Method to open and return a CacheDb instance
+    pub fn open(cache_dir: &str) -> CacheDb{
+        let conn = open_db_and_run_migration(
+            cache_dir,
+            "cache.db",  // Corrected file name
+            &vec![&|tx| {
+                let sql = "
+                    CREATE TABLE journey_cache (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL UNIQUE,
+                        data BLOB NOT NULL
+                    );
+                    CREATE TABLE setting (
+                        key TEXT PRIMARY KEY NOT NULL UNIQUE,
+                        value TEXT
+                    );
+                ";
+                for s in sql_split::split(sql) {
+                    tx.execute(&s, [])?;
+                }
+                Ok(())
+            }],
+        )
+        .expect("failed to open main db");
+        CacheDb { conn }
+    }
+
+    // Method to execute a transaction
+    pub fn with_txn<F, O>(&mut self, f: F) -> Result<O>
+    where
+        F: FnOnce(&Txn) -> Result<O>,
+    {
+        let txn = Txn {
+            db_txn: self.conn.transaction()?,
+        };
+        let output = f(&txn)?;
+        txn.db_txn.commit()?;
+        Ok(output)
+    }
+
+    // Method to flush the cache
+    pub fn flush(&self) -> Result<()> {
+        self.conn.cache_flush()?;
+        Ok(())
+    }
+}

--- a/app/rust/src/lib.rs
+++ b/app/rust/src/lib.rs
@@ -17,6 +17,7 @@ pub mod journey_data;
 pub mod journey_header;
 pub mod journey_vector;
 pub mod main_db;
+pub mod cache_db;
 pub mod map_renderer;
 mod merged_journey_manager;
 mod protos;

--- a/app/rust/src/lib.rs
+++ b/app/rust/src/lib.rs
@@ -10,6 +10,7 @@ mod frb_generated; /* AUTO INJECTED BY flutter_rust_bridge. This line may not be
 
 pub mod api;
 pub mod archive;
+pub mod cache_db;
 pub mod gps_processor;
 pub mod import_data;
 pub mod journey_bitmap;
@@ -17,9 +18,8 @@ pub mod journey_data;
 pub mod journey_header;
 pub mod journey_vector;
 pub mod main_db;
-pub mod cache_db;
 pub mod map_renderer;
-mod merged_journey_manager;
+pub mod merged_journey_manager;
 mod protos;
 pub mod storage;
 pub mod tile_renderer;

--- a/app/rust/src/storage.rs
+++ b/app/rust/src/storage.rs
@@ -8,6 +8,7 @@ use std::sync::Mutex;
 
 use crate::gps_processor::{self, ProcessResult};
 use crate::main_db::MainDb;
+use crate::cache_db::CacheDb;
 
 // TODO: error handling in this file is horrifying, we should think about what
 // is the right thing to do here.
@@ -87,6 +88,8 @@ pub struct Storage {
     support_dir: String,
     pub main_db: Mutex<MainDb>,
     raw_data_recorder: Mutex<Option<RawDataRecorder>>, // `None` means disabled
+    cache_dir: String,
+    pub cache_db: Mutex<CacheDb>
 }
 
 impl Storage {
@@ -94,9 +97,10 @@ impl Storage {
         _temp_dir: String,
         _doc_dir: String,
         support_dir: String,
-        _cache_dir: String,
+        cache_dir: String,
     ) -> Self {
         let mut main_db = MainDb::open(&support_dir);
+        let mut cache_db = CacheDb::open(&cache_dir);
         let raw_data_recorder =
             if main_db.get_setting_with_default(crate::main_db::Setting::RawDataMode, false) {
                 Some(RawDataRecorder::init(&support_dir))
@@ -107,6 +111,8 @@ impl Storage {
             support_dir,
             main_db: Mutex::new(main_db),
             raw_data_recorder: Mutex::new(raw_data_recorder),
+            cache_dir,
+            cache_db: Mutex::new(cache_db)
         }
     }
 

--- a/app/rust/src/storage.rs
+++ b/app/rust/src/storage.rs
@@ -6,9 +6,9 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
+use crate::cache_db::CacheDb;
 use crate::gps_processor::{self, ProcessResult};
 use crate::main_db::MainDb;
-use crate::cache_db::CacheDb;
 
 // TODO: error handling in this file is horrifying, we should think about what
 // is the right thing to do here.
@@ -88,8 +88,9 @@ pub struct Storage {
     support_dir: String,
     pub main_db: Mutex<MainDb>,
     raw_data_recorder: Mutex<Option<RawDataRecorder>>, // `None` means disabled
-    cache_dir: String,
-    pub cache_db: Mutex<CacheDb>
+    #[allow(dead_code)]
+    cache_dir: String,          // stored for future usage
+    pub cache_db: Mutex<CacheDb>,
 }
 
 impl Storage {
@@ -100,7 +101,7 @@ impl Storage {
         cache_dir: String,
     ) -> Self {
         let mut main_db = MainDb::open(&support_dir);
-        let mut cache_db = CacheDb::open(&cache_dir);
+        let cache_db = CacheDb::open(&cache_dir);
         let raw_data_recorder =
             if main_db.get_setting_with_default(crate::main_db::Setting::RawDataMode, false) {
                 Some(RawDataRecorder::init(&support_dir))
@@ -112,7 +113,7 @@ impl Storage {
             main_db: Mutex::new(main_db),
             raw_data_recorder: Mutex::new(raw_data_recorder),
             cache_dir,
-            cache_db: Mutex::new(cache_db)
+            cache_db: Mutex::new(cache_db),
         }
     }
 

--- a/app/rust/tests/cache_db.rs
+++ b/app/rust/tests/cache_db.rs
@@ -1,0 +1,40 @@
+pub mod test_utils;
+
+use rust_lib::{cache_db::CacheDb, journey_bitmap::JourneyBitmap, journey_data::JourneyData};
+use tempdir::TempDir;
+
+use crate::test_utils::draw_sample_bitmap;
+
+#[test]
+fn basic() {
+    let cache_dir = TempDir::new("cache_db-basic").unwrap();
+    println!("cache dir: {:?}", cache_dir.path());
+
+    let mut cache_db = CacheDb::open(cache_dir.path().to_str().unwrap());
+
+    let journey_bitmap = draw_sample_bitmap().unwrap();
+    let journey_data = JourneyData::Bitmap(journey_bitmap);
+
+    let mut buf = Vec::new();
+    journey_data.serialize(&mut buf).unwrap();
+
+    println!("size: {}", buf.len());
+
+    cache_db
+        .with_txn(|txn| txn.insert_journey_bitmap_blob(buf))
+        .unwrap();
+
+    // validate the cached journey
+    let journey_cache = cache_db.with_txn(|txn| txn.get_journey()).unwrap();
+
+    assert_eq!(journey_data, journey_cache);
+
+    let mut journey_bitmap_from_cache = JourneyBitmap::new();
+    match journey_cache {
+        JourneyData::Bitmap(bitmap) => journey_bitmap_from_cache.merge(bitmap),
+        _ => panic!("Expected bitmap data"),
+    }
+
+    let journey_bitmap = draw_sample_bitmap().unwrap();
+    assert_eq!(journey_bitmap, journey_bitmap_from_cache);
+}

--- a/app/rust/tests/merged_journey_manager.rs
+++ b/app/rust/tests/merged_journey_manager.rs
@@ -1,0 +1,58 @@
+pub mod test_utils;
+use chrono::Utc;
+use rust_lib::{
+    cache_db::CacheDb, journey_bitmap::JourneyBitmap, journey_data::JourneyData,
+    journey_header::JourneyKind, main_db::MainDb, merged_journey_manager,
+};
+use tempdir::TempDir;
+
+use crate::test_utils::draw_sample_bitmap;
+
+#[test]
+fn basic() {
+    let cache_dir = TempDir::new("cache_db-basic").unwrap();
+    println!("cache dir: {:?}", cache_dir.path());
+    let mut cache_db = CacheDb::open(cache_dir.path().to_str().unwrap());
+
+    let temp_dir = TempDir::new("main_db-basic").unwrap();
+    println!("temp dir: {:?}", temp_dir.path());
+    let mut main_db = MainDb::open(temp_dir.path().to_str().unwrap());
+
+    let journey_bitmap = draw_sample_bitmap().unwrap();
+
+    main_db
+        .with_txn(|txn| {
+            txn.create_and_insert_journey(
+                Some(Utc::now()),
+                Utc::now(),
+                Some(Utc::now()),
+                JourneyKind::Default,
+                Some("Sample note".to_string()),
+                JourneyData::Bitmap(journey_bitmap),
+            )
+        })
+        .unwrap();
+
+    let journey_bitmap_from_db =
+        merged_journey_manager::get_latest_including_ongoing(&mut main_db, &mut cache_db).unwrap();
+    let journey_bitmap = draw_sample_bitmap().unwrap();
+
+    assert_eq!(journey_bitmap, journey_bitmap_from_db);
+
+    // validate the cached journey
+    let journey_cache = cache_db.with_txn(|txn| txn.get_journey()).unwrap();
+
+    let mut journey_bitmap_from_cache = JourneyBitmap::new();
+    match journey_cache {
+        JourneyData::Bitmap(bitmap) => journey_bitmap_from_cache.merge(bitmap),
+        _ => panic!("Expected bitmap data"),
+    }
+
+    assert_eq!(journey_bitmap, journey_bitmap_from_cache);
+
+    let journey_bitmap_from_db_2nd =
+        merged_journey_manager::get_latest_including_ongoing(&mut main_db, &mut cache_db).unwrap();
+    assert_eq!(journey_bitmap_from_db_2nd, journey_bitmap_from_cache);
+}
+
+// TODO: add tests for modifying results and invalidate cache

--- a/app/rust/tests/test_utils/mod.rs
+++ b/app/rust/tests/test_utils/mod.rs
@@ -1,8 +1,8 @@
 use chrono::NaiveDateTime;
 use hex::ToHex;
-use rust_lib::gps_processor;
+use rust_lib::{gps_processor, journey_bitmap::JourneyBitmap};
 use sha1::{Digest, Sha1};
-use std::{fs::File, io::Write};
+use std::{convert::Infallible, fs::File, io::Write};
 
 pub fn load_raw_gpx_data_for_test() -> Vec<gps_processor::RawData> {
     let mut reader = csv::ReaderBuilder::new()
@@ -52,4 +52,34 @@ pub fn assert_image(
     hasher.update(data);
     let result = hasher.finalize();
     assert_eq!(result.encode_hex::<String>(), expect_hash);
+}
+
+const START_LNG: f64 = 151.1435370795134;
+const START_LAT: f64 = -33.793291910360125;
+const END_LNG: f64 = 151.2783692841415;
+const END_LAT: f64 = -33.943600147192235;
+const MID_LNG: f64 = (START_LNG + END_LNG) / 2.;
+const MID_LAT: f64 = (START_LAT + END_LAT) / 2.;
+
+fn draw_line1(journey_bitmap: &mut JourneyBitmap) {
+    journey_bitmap.add_line(START_LNG, START_LAT, END_LNG, END_LAT)
+}
+fn draw_line2(journey_bitmap: &mut JourneyBitmap) {
+    journey_bitmap.add_line(START_LNG, END_LAT, END_LNG, START_LAT);
+}
+fn draw_line3(journey_bitmap: &mut JourneyBitmap) {
+    journey_bitmap.add_line(MID_LNG, START_LAT, MID_LNG, END_LAT)
+}
+fn draw_line4(journey_bitmap: &mut JourneyBitmap) {
+    journey_bitmap.add_line(START_LNG, MID_LAT, END_LNG, MID_LAT)
+}
+
+pub fn draw_sample_bitmap() -> Result<JourneyBitmap, Infallible> {
+    let mut journey_bitmap = JourneyBitmap::new();
+    draw_line1(&mut journey_bitmap);
+    draw_line2(&mut journey_bitmap);
+    draw_line3(&mut journey_bitmap);
+    draw_line4(&mut journey_bitmap);
+
+    Ok(journey_bitmap)
 }


### PR DESCRIPTION
Cache V0:
1. Add a cache db that stores serialized bitmap from main db
2. merged_journey_manager will try to read from cache db, and fall back to main db if failed

TODO: 
v0: invalidate/delete cache if bitmap changes
v1: add timestamps to track cache validity


