### PR TITLE
Introducing journey date

### DIFF
--- a/app/rust/Cargo.lock
+++ b/app/rust/Cargo.lock
@@ -819,6 +819,7 @@ dependencies = [
  "hex",
  "integer-encoding",
  "itertools",
+ "lazy_static",
  "log",
  "protobuf",
  "protobuf-codegen",

--- a/app/rust/Cargo.toml
+++ b/app/rust/Cargo.toml
@@ -28,6 +28,7 @@ sha1 = "0.10.5"
 hex = "0.4.3"
 integer-encoding = "4.0.0"
 flate2 = "1.0.28"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/app/rust/src/api/api.rs
+++ b/app/rust/src/api/api.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::sync::{Mutex, OnceLock};
 
 use anyhow::{Ok, Result};
-use chrono::Utc;
+use chrono::{Local, Utc};
 use simplelog::{Config, LevelFilter, WriteLogger};
 
 use crate::gps_processor::{GpsProcessor, ProcessResult};
@@ -156,6 +156,7 @@ pub fn import_fow_data(zip_file_path: String) -> Result<()> {
     let mut main_db = get().storage.main_db.lock().unwrap();
     main_db.with_txn(|txn| {
         txn.create_and_insert_journey(
+            Local::now().date_naive(),
             None,
             Utc::now(),
             None,

--- a/app/rust/src/journey_header.rs
+++ b/app/rust/src/journey_header.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use protobuf::EnumOrUnknown;
 use strum_macros::EnumIter;
 
@@ -94,7 +94,7 @@ impl JourneyKind {
 pub struct JourneyHeader {
     pub id: String,
     pub revision: String,
-    pub journey_date: NaiveDate,
+    pub journey_date: chrono::NaiveDate,
     pub created_at: DateTime<Utc>,
     pub updated_at: Option<DateTime<Utc>>,
     pub start: Option<DateTime<Utc>>,

--- a/app/rust/src/journey_header.rs
+++ b/app/rust/src/journey_header.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use protobuf::EnumOrUnknown;
 use strum_macros::EnumIter;
 
-use crate::protos;
+use crate::{protos, utils};
 
 #[derive(Copy, Clone, Debug, EnumIter, PartialEq, Eq, Hash)]
 #[repr(i8)]
@@ -94,10 +94,11 @@ impl JourneyKind {
 pub struct JourneyHeader {
     pub id: String,
     pub revision: String,
+    pub journey_date: NaiveDate,
     pub created_at: DateTime<Utc>,
     pub updated_at: Option<DateTime<Utc>>,
-    pub end: DateTime<Utc>,
     pub start: Option<DateTime<Utc>>,
+    pub end: DateTime<Utc>,
     pub journey_type: JourneyType,
     pub journey_kind: JourneyKind,
     pub note: Option<String>,
@@ -109,16 +110,24 @@ impl JourneyHeader {
             .type_
             .enum_value()
             .map_err(|x| anyhow!("Unknown proto journey type: {}", x))?;
+        let end = DateTime::from_timestamp(proto.end__timestamp_sec, 0).unwrap();
+        // TODO: We only need this during the "migration". We should drop it later (we could drop it because we haven't
+        // make any promise on stability).
+        let journey_date = match proto.journey_date__days_since_epoch {
+            None => end.date_naive(),
+            Some(days) => utils::date_of_days_since_epoch(days).unwrap(),
+        };
         Ok(JourneyHeader {
             id: proto.id,
             revision: proto.revision,
-            created_at: DateTime::from_timestamp(proto.created_at_timestamp_sec, 0).unwrap(),
+            journey_date,
+            created_at: DateTime::from_timestamp(proto.created_at__timestamp_sec, 0).unwrap(),
             updated_at: proto
-                .updated_at_timestamp_sec
+                .updated_at__timestamp_sec
                 .and_then(|sec| DateTime::from_timestamp(sec, 0)),
-            end: DateTime::from_timestamp(proto.end_timestamp_sec, 0).unwrap(),
+            end,
             start: proto
-                .start_timestamp_sec
+                .start__timestamp_sec
                 .and_then(|sec| DateTime::from_timestamp(sec, 0)),
             journey_type: JourneyType::of_proto(journey_type),
             journey_kind: JourneyKind::of_proto(match proto.kind.take() {
@@ -133,10 +142,12 @@ impl JourneyHeader {
         let mut proto = protos::journey::Header::new();
         proto.id = self.id;
         proto.revision = self.revision;
-        proto.created_at_timestamp_sec = self.created_at.timestamp();
-        proto.updated_at_timestamp_sec = self.updated_at.map(|x| x.timestamp());
-        proto.end_timestamp_sec = self.end.timestamp();
-        proto.start_timestamp_sec = self.start.map(|x| x.timestamp());
+        proto.journey_date__days_since_epoch =
+            Some(utils::date_to_days_since_epoch(self.journey_date));
+        proto.created_at__timestamp_sec = self.created_at.timestamp();
+        proto.updated_at__timestamp_sec = self.updated_at.map(|x| x.timestamp());
+        proto.end__timestamp_sec = self.end.timestamp();
+        proto.start__timestamp_sec = self.start.map(|x| x.timestamp());
         proto.type_ = EnumOrUnknown::new(self.journey_type.to_proto());
         proto.kind.0 = Some(Box::new(self.journey_kind.to_proto()));
         proto.note = self.note;

--- a/app/rust/src/lib.rs
+++ b/app/rust/src/lib.rs
@@ -4,6 +4,8 @@
 extern crate log;
 #[macro_use]
 extern crate anyhow;
+#[macro_use]
+extern crate lazy_static;
 
 mod frb_generated; /* AUTO INJECTED BY flutter_rust_bridge. This line may not be accurate, and you can change it according to your needs. */
 

--- a/app/rust/src/main_db.rs
+++ b/app/rust/src/main_db.rs
@@ -1,6 +1,6 @@
 extern crate simplelog;
 use anyhow::Result;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use protobuf::Message;
 use rusqlite::{Connection, OptionalExtension, Transaction};
 use std::cmp::Ordering;
@@ -189,6 +189,7 @@ impl Txn<'_> {
 
     pub fn create_and_insert_journey(
         &self,
+        journey_date: NaiveDate,
         start: Option<DateTime<Utc>>,
         end: DateTime<Utc>,
         created_at: Option<DateTime<Utc>>,
@@ -203,6 +204,7 @@ impl Txn<'_> {
             // we use id + revision as the equality check, revision can be any
             // string (e.g. uuid) but a short random should be good enough.
             revision: random_string::generate(8, random_string::charsets::ALPHANUMERIC),
+            journey_date,
             created_at: created_at.unwrap_or(Utc::now()),
             updated_at: None,
             end,
@@ -229,6 +231,7 @@ impl Txn<'_> {
                 let journey_kind = JourneyKind::DefaultKind;
 
                 self.create_and_insert_journey(
+                    end.date_naive(),
                     Some(start),
                     end,
                     None,

--- a/app/rust/src/main_db.rs
+++ b/app/rust/src/main_db.rs
@@ -190,6 +190,7 @@ impl Txn<'_> {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn create_and_insert_journey(
         &self,
         journey_date: NaiveDate,

--- a/app/rust/src/protos/journey.proto
+++ b/app/rust/src/protos/journey.proto
@@ -22,10 +22,13 @@ message Header {
 
   string id = 1;
   string revision = 2;
-  int64 created_at_timestamp_sec = 3;
-  optional int64 updated_at_timestamp_sec = 4;
-  int64 end_timestamp_sec = 5;
-  optional int64 start_timestamp_sec = 6;
+  // TODO: after migration, make `journy_date`` not optional and `end` optional
+  optional int32 journey_date__days_since_epoch = 10;
+  int64 created_at__timestamp_sec = 3;
+  optional int64 updated_at__timestamp_sec = 4;
+  // TODO: consider add timezone for `start` and `end`.
+  optional int64 start__timestamp_sec = 6;
+  int64 end__timestamp_sec = 5;
   Type type = 7;
   Kind kind = 8;
   optional string note = 9;

--- a/app/rust/src/utils.rs
+++ b/app/rust/src/utils.rs
@@ -1,5 +1,7 @@
 use std::f64::consts::PI;
 
+use chrono::{Datelike, NaiveDate};
+
 // https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames
 pub fn lng_lat_to_tile_x_y(lng: f64, lat: f64, zoom: i32) -> (i32, i32) {
     let n = f64::powi(2.0, zoom);
@@ -14,4 +16,41 @@ pub fn tile_x_y_to_lng_lat(x: i32, y: i32, zoom: i32) -> (f64, f64) {
     let lng = (x as f64 / n) * 360.0 - 180.0;
     let lat = (f64::atan(f64::sinh(PI * (1.0 - (2.0 * y as f64) / n))) * 180.0) / PI;
     (lng, lat)
+}
+
+// We could just use num days from ce instead of epoch, but ce is quite far
+// away and we use varint for serialization, so epoch can make it a bit more
+// efficient.
+lazy_static! {
+    static ref EPOCH_NUM_OF_DAYS_FROM_CE: i32 = NaiveDate::from_ymd_opt(1970, 1, 1)
+        .unwrap()
+        .num_days_from_ce();
+}
+
+pub fn date_to_days_since_epoch(date: NaiveDate) -> i32 {
+    date.num_days_from_ce() - *EPOCH_NUM_OF_DAYS_FROM_CE
+}
+
+pub fn date_of_days_since_epoch(days: i32) -> Option<NaiveDate> {
+    NaiveDate::from_num_days_from_ce_opt(days + *EPOCH_NUM_OF_DAYS_FROM_CE)
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDate;
+
+    use crate::utils::{date_of_days_since_epoch, date_to_days_since_epoch};
+
+    #[test]
+    fn days_since_epoch() {
+        let check = |y, m, d, expected_days| {
+            let date = NaiveDate::from_ymd_opt(y, m, d).unwrap();
+            let days = date_to_days_since_epoch(date);
+            assert_eq!(days, expected_days);
+            assert_eq!(date, date_of_days_since_epoch(days).unwrap());
+        };
+        check(1970, 1, 1, 0);
+        check(2024, 2, 29, 19782);
+        check(1938, 8, 23, -11454);
+    }
 }

--- a/app/rust/tests/archive.rs
+++ b/app/rust/tests/archive.rs
@@ -30,6 +30,7 @@ fn add_bitmap_journey(main_db: &mut MainDb) {
     main_db
         .with_txn(|txn| {
             txn.create_and_insert_journey(
+                Utc::now().date_naive(),
                 None,
                 Utc::now(),
                 None,


### PR DESCRIPTION
Per our offline discussion, we are introducing a new concept: `journey_date`. The min granularity of history in this app is day and each journey is an atomic entry attach to each day using `journey_date`. We believe this is better than using the old `end_time` approach because it handles timezone slightly better and make the concept of `end_time` less overloaded. Now `end_time` is just a normal metadata.

We haven't made our stability guarantee yet. This change has incompatible changes to maindb so all installation need a clean reset. The archive format is backward compatible.