### PR TITLE
Journey date migration

### DIFF
--- a/app/rust/src/api/api.rs
+++ b/app/rust/src/api/api.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::sync::{Mutex, OnceLock};
 
 use anyhow::{Ok, Result};
-use chrono::{Local, Utc};
+use chrono::Local;
 use simplelog::{Config, LevelFilter, WriteLogger};
 
 use crate::gps_processor::{GpsProcessor, ProcessResult};
@@ -158,7 +158,7 @@ pub fn import_fow_data(zip_file_path: String) -> Result<()> {
         txn.create_and_insert_journey(
             Local::now().date_naive(),
             None,
-            Utc::now(),
+            None,
             None,
             JourneyKind::DefaultKind,
             None,

--- a/app/rust/src/archive.rs
+++ b/app/rust/src/archive.rs
@@ -147,8 +147,8 @@ pub fn archive_all_as_zip<T: Write + Seek>(main_db: &mut MainDb, writer: &mut T)
         let mut group_by_year_month = HashMap::new();
         for journey in all_journeys {
             let year_month = YearMonth {
-                year: journey.end.year() as i16,
-                month: journey.end.month() as u8,
+                year: journey.journey_date.year() as i16,
+                month: journey.journey_date.month() as u8,
             };
             group_by_year_month
                 .entry(year_month)
@@ -195,8 +195,6 @@ pub fn archive_all_as_zip<T: Write + Seek>(main_db: &mut MainDb, writer: &mut T)
         metadata_proto.note = None;
         for (_, section_id, journeys) in &to_process {
             let mut section_info = metadata::SectionInfo::new();
-            section_info.first_journey_timestamp_sec = journeys.first().unwrap().end.timestamp();
-            section_info.last_journey_timestamp_sec = journeys.last().unwrap().end.timestamp();
             section_info.section_id = section_id.clone();
             section_info.num_of_journeys = journeys.len() as u32;
             metadata_proto.section_infos.push(section_info)

--- a/app/rust/src/journey_header.rs
+++ b/app/rust/src/journey_header.rs
@@ -98,7 +98,7 @@ pub struct JourneyHeader {
     pub created_at: DateTime<Utc>,
     pub updated_at: Option<DateTime<Utc>>,
     pub start: Option<DateTime<Utc>>,
-    pub end: DateTime<Utc>,
+    pub end: Option<DateTime<Utc>>,
     pub journey_type: JourneyType,
     pub journey_kind: JourneyKind,
     pub note: Option<String>,
@@ -110,22 +110,18 @@ impl JourneyHeader {
             .type_
             .enum_value()
             .map_err(|x| anyhow!("Unknown proto journey type: {}", x))?;
-        let end = DateTime::from_timestamp(proto.end__timestamp_sec, 0).unwrap();
-        // TODO: We only need this during the "migration". We should drop it later (we could drop it because we haven't
-        // make any promise on stability).
-        let journey_date = match proto.journey_date__days_since_epoch {
-            None => end.date_naive(),
-            Some(days) => utils::date_of_days_since_epoch(days).unwrap(),
-        };
         Ok(JourneyHeader {
             id: proto.id,
             revision: proto.revision,
-            journey_date,
+            journey_date: utils::date_of_days_since_epoch(proto.journey_date__days_since_epoch)
+                .unwrap(),
             created_at: DateTime::from_timestamp(proto.created_at__timestamp_sec, 0).unwrap(),
             updated_at: proto
                 .updated_at__timestamp_sec
                 .and_then(|sec| DateTime::from_timestamp(sec, 0)),
-            end,
+            end: proto
+                .end__timestamp_sec
+                .and_then(|sec| DateTime::from_timestamp(sec, 0)),
             start: proto
                 .start__timestamp_sec
                 .and_then(|sec| DateTime::from_timestamp(sec, 0)),
@@ -142,11 +138,10 @@ impl JourneyHeader {
         let mut proto = protos::journey::Header::new();
         proto.id = self.id;
         proto.revision = self.revision;
-        proto.journey_date__days_since_epoch =
-            Some(utils::date_to_days_since_epoch(self.journey_date));
+        proto.journey_date__days_since_epoch = utils::date_to_days_since_epoch(self.journey_date);
         proto.created_at__timestamp_sec = self.created_at.timestamp();
         proto.updated_at__timestamp_sec = self.updated_at.map(|x| x.timestamp());
-        proto.end__timestamp_sec = self.end.timestamp();
+        proto.end__timestamp_sec = self.end.map(|x| x.timestamp());
         proto.start__timestamp_sec = self.start.map(|x| x.timestamp());
         proto.type_ = EnumOrUnknown::new(self.journey_type.to_proto());
         proto.kind.0 = Some(Box::new(self.journey_kind.to_proto()));

--- a/app/rust/src/protos/archive.proto
+++ b/app/rust/src/protos/archive.proto
@@ -12,8 +12,6 @@ message Metadata {
     }
     message SectionInfo {
         string section_id = 1;
-        int64 first_journey_timestamp_sec = 2;
-        int64 last_journey_timestamp_sec = 3;
         uint32 num_of_journeys = 4;
     }
 

--- a/app/rust/src/protos/journey.proto
+++ b/app/rust/src/protos/journey.proto
@@ -22,13 +22,12 @@ message Header {
 
   string id = 1;
   string revision = 2;
-  // TODO: after migration, make `journy_date`` not optional and `end` optional
-  optional int32 journey_date__days_since_epoch = 10;
+  int32 journey_date__days_since_epoch = 10;
   int64 created_at__timestamp_sec = 3;
   optional int64 updated_at__timestamp_sec = 4;
   // TODO: consider add timezone for `start` and `end`.
   optional int64 start__timestamp_sec = 6;
-  int64 end__timestamp_sec = 5;
+  optional int64 end__timestamp_sec = 5;
   Type type = 7;
   Kind kind = 8;
   optional string note = 9;

--- a/app/rust/tests/archive.rs
+++ b/app/rust/tests/archive.rs
@@ -32,7 +32,7 @@ fn add_bitmap_journey(main_db: &mut MainDb) {
             txn.create_and_insert_journey(
                 Utc::now().date_naive(),
                 None,
-                Utc::now(),
+                None,
                 None,
                 memolanes_core::journey_header::JourneyKind::DefaultKind,
                 None,


### PR DESCRIPTION
The second part of #60.
After this, archive before #60 can not be loaded. So one need to loaded using #60 and then export a new one.