### PR TITLE
Fix Rust code analysis

### DIFF
--- a/app/rust/src/archive.rs
+++ b/app/rust/src/archive.rs
@@ -192,7 +192,7 @@ pub fn archive_all_as_zip<T: Write + Seek>(txn: &main_db::Txn, writer: &mut T) -
     metadata_proto.note = None;
     for (_, section_id, journeys) in &to_process {
         let mut section_info = metadata::SectionInfo::new();
-        section_info.section_id = section_id.clone();
+        section_info.section_id.clone_from(section_id);
         section_info.num_of_journeys = journeys.len() as u32;
         metadata_proto.section_infos.push(section_info)
     }
@@ -209,7 +209,7 @@ pub fn archive_all_as_zip<T: Write + Seek>(txn: &main_db::Txn, writer: &mut T) -
     // writing section data
     for (_, section_id, journeys) in &to_process {
         let mut section_header = SectionHeader::new();
-        section_header.section_id = section_id.clone();
+        section_header.section_id.clone_from(section_id);
         for j in journeys {
             section_header.journey_headers.push(j.clone().to_proto());
         }


### PR DESCRIPTION
Maybe due to the Rust Clippy version upgrade

```
error: assigning the result of `Clone::clone()` may be inefficient
   --> src/archive.rs:195:9
    |
195 |         section_info.section_id = section_id.clone();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_from()`: `section_info.section_id.clone_from(section_id)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones
    = note: `-D clippy::assigning-clones` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::assigning_clones)]`

error: assigning the result of `Clone::clone()` may be inefficient
   --> src/archive.rs:2[12](https://github.com/MemoLanes/MemoLanes/actions/runs/8949337130/job/24583542723?pr=84#step:14:13):9
    |
212 |         section_header.section_id = section_id.clone();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_from()`: `section_header.section_id.clone_from(section_id)`
```