### PR TITLE
Fix a bug in `_loadMapState`

### DIFF
--- a/app/lib/map.dart
+++ b/app/lib/map.dart
@@ -191,17 +191,8 @@ class MapUiBodyState extends State<MapUiBody> with WidgetsBindingObserver {
       cameraOptions.center =
           Point(coordinates: Position(mapState.lng, mapState.lat));
     } else {
-      geolocator.Position? lastKnownPosition =
-          await geolocator.Geolocator.getLastKnownPosition();
-      if (lastKnownPosition != null) {
-        cameraOptions.zoom = 16;
-        cameraOptions.center = Point(
-            coordinates: Position(
-                lastKnownPosition.longitude, lastKnownPosition.latitude));
-      } else {
-        // nothing we can use, just look at the whole earth
-        cameraOptions.zoom = 2;
-      }
+      // nothing we can use, just look at the whole earth
+      cameraOptions.zoom = 2;
     }
 
     setState(() {


### PR DESCRIPTION
`geolocator.Geolocator.getLastKnownPosition` may raise exception when it does not have enough permission.
Now I think about it, falling back to `geolocator.Geolocator.getLastKnownPosition` does not make a lot of sense anyway. If we don't have saved map state, it is very likely that it is the first time opening the app. In this case, we don't have location permission anyway.