### PR TITLE
Map rendering related refactor for reusability

### DIFF
--- a/app/lib/component/base_map.dart
+++ b/app/lib/component/base_map.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
-import 'package:memolanes/src/rust/api/api.dart';
+import 'package:memolanes/src/rust/api/api.dart' as api;
 import 'package:memolanes/token.dart';
 
 class MapController {
@@ -12,11 +12,13 @@ class MapController {
 }
 
 class BaseMap extends StatefulWidget {
+  final api.MapRendererProxy mapRendererProxy;
   final CameraOptions initialCameraOptions;
   final void Function(MapController mapController) onMapCreated;
   final OnMapScrollListener? onScrollListener;
   const BaseMap(
       {super.key,
+      required this.mapRendererProxy,
       required this.initialCameraOptions,
       required this.onMapCreated,
       this.onScrollListener});
@@ -57,7 +59,7 @@ class BaseMapState extends State<BaseMap> {
     final right = northeast[0];
     final bottom = southwest[1];
 
-    final renderResult = await renderMapOverlay(
+    final renderResult = await widget.mapRendererProxy.renderMapOverlay(
       zoom: zoom,
       left: left!.toDouble(),
       top: top!.toDouble(),
@@ -101,7 +103,7 @@ class BaseMapState extends State<BaseMap> {
   }
 
   void _refreshLoop() async {
-    await resetMapRenderer();
+    await widget.mapRendererProxy.resetMapRenderer();
     while (true) {
       await requireRefresh?.future;
       if (requireRefresh == null) return;

--- a/app/lib/component/base_map.dart
+++ b/app/lib/component/base_map.dart
@@ -1,0 +1,159 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
+import 'package:memolanes/src/rust/api/api.dart';
+import 'package:memolanes/token.dart';
+
+class MapController {
+  final MapboxMap mapboxMap;
+  final void Function() triggerRefresh;
+
+  MapController(this.mapboxMap, this.triggerRefresh);
+}
+
+class BaseMap extends StatefulWidget {
+  final CameraOptions initialCameraOptions;
+  final void Function(MapController mapController) onMapCreated;
+  final OnMapScrollListener? onScrollListener;
+  const BaseMap(
+      {super.key,
+      required this.initialCameraOptions,
+      required this.onMapCreated,
+      this.onScrollListener});
+
+  @override
+  State<StatefulWidget> createState() => BaseMapState();
+}
+
+class BaseMapState extends State<BaseMap> {
+  static const String overlayLayerId = "overlay-layer";
+  static const String overlayImageSourceId = "overlay-image-source";
+
+  BaseMapState() {
+    // TODO: Kinda want the default implementation is maplibre instead of mapbox.
+    // However maplibre is very buggy + lack of global view +
+    // cannot handle antimeridian well.
+    MapboxOptions.setAccessToken(token["MAPBOX-ACCESS-TOKEN"]);
+  }
+
+  MapController? _mapController;
+  bool layerAdded = false;
+  Completer? requireRefresh = Completer();
+
+  Future<void> _doActualRefresh() async {
+    var mapboxMap = _mapController?.mapboxMap;
+    if (mapboxMap == null) return;
+
+    final cameraState = await mapboxMap.getCameraState();
+    final zoom = cameraState.zoom;
+    final coordinateBounds = await mapboxMap.coordinateBoundsForCamera(
+        CameraOptions(
+            center: cameraState.center, zoom: zoom, pitch: cameraState.pitch));
+    final northeast = coordinateBounds.northeast.coordinates;
+    final southwest = coordinateBounds.southwest.coordinates;
+
+    final left = southwest[0];
+    final top = northeast[1];
+    final right = northeast[0];
+    final bottom = southwest[1];
+
+    final renderResult = await renderMapOverlay(
+      zoom: zoom,
+      left: left!.toDouble(),
+      top: top!.toDouble(),
+      right: right!.toDouble(),
+      bottom: bottom!.toDouble(),
+    );
+
+    if (renderResult != null) {
+      final coordinates = [
+        [renderResult.left, renderResult.top],
+        [renderResult.right, renderResult.top],
+        [renderResult.right, renderResult.bottom],
+        [renderResult.left, renderResult.bottom]
+      ];
+      final image = MbxImage(
+          width: renderResult.width,
+          height: renderResult.height,
+          data: renderResult.data);
+
+      if (!mounted) return;
+      // TODO: we kinda need transaction to avoid flickering
+      if (layerAdded) {
+        await Future.wait([
+          mapboxMap.style
+              .updateStyleImageSourceImage(overlayImageSourceId, image),
+          mapboxMap.style.setStyleSourceProperty(
+              overlayImageSourceId, "coordinates", coordinates)
+        ]);
+      } else {
+        layerAdded = true;
+        await mapboxMap.style.addSource(
+            ImageSource(id: overlayImageSourceId, coordinates: coordinates));
+        await mapboxMap.style.addLayer(RasterLayer(
+          id: overlayLayerId,
+          sourceId: overlayImageSourceId,
+        ));
+        await mapboxMap.style
+            .updateStyleImageSourceImage(overlayImageSourceId, image);
+      }
+    }
+  }
+
+  void _refreshLoop() async {
+    await resetMapRenderer();
+    while (true) {
+      await requireRefresh?.future;
+      if (requireRefresh == null) return;
+      // make it ready for the next request
+      requireRefresh = Completer();
+
+      await _doActualRefresh();
+    }
+  }
+
+  void _triggerRefresh() async {
+    if (requireRefresh?.isCompleted == false) {
+      requireRefresh?.complete();
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _refreshLoop();
+  }
+
+  @override
+  void dispose() {
+    if (requireRefresh?.isCompleted == false) {
+      requireRefresh?.complete();
+    }
+    requireRefresh = null;
+    super.dispose();
+  }
+
+  _onMapCreated(MapboxMap mapboxMap) async {
+    await mapboxMap.gestures
+        .updateSettings(GesturesSettings(pitchEnabled: false));
+    final mapController = MapController(mapboxMap, _triggerRefresh);
+    _mapController = mapController;
+    widget.onMapCreated(mapController);
+  }
+
+  _onCameraChangeListener(CameraChangedEventData event) {
+    _triggerRefresh();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MapWidget(
+      key: widget.key,
+      onMapCreated: _onMapCreated,
+      onCameraChangeListener: _onCameraChangeListener,
+      styleUri: MapboxStyles.OUTDOORS,
+      cameraOptions: widget.initialCameraOptions,
+      onScrollListener: widget.onScrollListener,
+    );
+  }
+}

--- a/app/lib/map.dart
+++ b/app/lib/map.dart
@@ -53,15 +53,11 @@ extension PuckPosition on StyleManager {
 }
 
 class MapUiBodyState extends State<MapUiBody> with WidgetsBindingObserver {
-  static const String overlayLayerId = "overlay-layer";
-  static const String overlayImageSourceId = "overlay-image-source";
   static const String mainMapStatePrefsKey = "MainMap.mapState";
 
   MapUiBodyState();
 
   MapController? mapController;
-  bool layerAdded = false;
-  Completer? requireRefresh = Completer();
   Timer? refreshTimer;
   Timer? trackTimer;
   TrackingMode trackingMode = TrackingMode.displayAndTracking;
@@ -133,10 +129,6 @@ class MapUiBodyState extends State<MapUiBody> with WidgetsBindingObserver {
     WidgetsBinding.instance.removeObserver(this);
     refreshTimer?.cancel();
     trackTimer?.cancel();
-    if (requireRefresh?.isCompleted == false) {
-      requireRefresh?.complete();
-    }
-    requireRefresh = null;
     super.dispose();
   }
 

--- a/app/lib/map.dart
+++ b/app/lib/map.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:memolanes/component/base_map.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:memolanes/src/rust/api/api.dart' as api;
 import 'package:json_annotation/json_annotation.dart';
 
 part 'map.g.dart';
@@ -215,12 +216,14 @@ class MapUiBodyState extends State<MapUiBody> with WidgetsBindingObserver {
   @override
   Widget build(BuildContext context) {
     final initialCameraOptions = _initialCameraOptions;
+    final mapRendererProxy = api.getMapRendererProxyForMainMap();
     if (initialCameraOptions == null) {
       return const CircularProgressIndicator();
     } else {
       return Scaffold(
         body: (BaseMap(
           key: const ValueKey("mapWidget"),
+          mapRendererProxy: mapRendererProxy,
           initialCameraOptions: initialCameraOptions,
           onMapCreated: _onMapCreated,
           onScrollListener: _onMapScrollListener,

--- a/app/rust/tests/end_to_end.rs
+++ b/app/rust/tests/end_to_end.rs
@@ -24,6 +24,7 @@ fn basic() {
 
     let mut raw_data_list = test_utils::load_raw_gpx_data_for_test();
     let (first_elements, remaining_elements) = raw_data_list.split_at_mut(2000);
+    let mut map_renderer_proxy = api::get_map_renderer_proxy_for_main_map();
 
     for (i, raw_data) in first_elements.iter().enumerate() {
         api::on_location_update(
@@ -41,8 +42,9 @@ fn basic() {
             let _: bool = api::finalize_ongoing_journey().unwrap();
         } else if i == 2000 {
             // we have both ongoing journey and finalized journey at this point
-            let render_result =
-                api::render_map_overlay(11.0, 121.39, 31.3146, 121.55, 31.18).unwrap();
+            let render_result = map_renderer_proxy
+                .render_map_overlay(11.0, 121.39, 31.3146, 121.55, 31.18)
+                .unwrap();
             test_utils::assert_image(
                 &render_result.data,
                 "end_to_end_basic_0",
@@ -55,7 +57,9 @@ fn basic() {
     api::on_location_update(remaining_elements.to_vec(), 1695150531000);
 
     // this should cover real time update
-    let render_result = api::render_map_overlay(11.0, 121.39, 31.3146, 121.55, 31.18).unwrap();
+    let render_result = map_renderer_proxy
+        .render_map_overlay(11.0, 121.39, 31.3146, 121.55, 31.18)
+        .unwrap();
     test_utils::assert_image(
         &render_result.data,
         "end_to_end_basic_1",


### PR DESCRIPTION
- Introduce `BaseMap` widget which can be used for both main map and individual static map.
- Introduce `MapRendererProxy` for better api between rust and flutter.