### PR TITLE
Setup x86_64 android workaround

### DIFF
--- a/app/rust/build.rs
+++ b/app/rust/build.rs
@@ -1,5 +1,39 @@
+use std::env;
+use std::path::Path;
 use std::process::Command;
 use std::{fs, io::Write};
+
+/// Adds a temporary workaround for an issue with the Rust compiler and Android
+/// in x86_64 devices: https://github.com/rust-lang/rust/issues/109717.
+/// The workaround comes from: https://github.com/mozilla/application-services/pull/5442
+fn setup_x86_64_android_workaround() {
+    const DEFAULT_CLANG_VERSION: &str = "17";
+    let target_os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not set");
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH not set");
+    let build_os = match env::consts::OS {
+        "linux" => "linux",
+        "macos" => "darwin",
+        "windows" => "windows",
+        _ => panic!(
+            "Unsupported OS. You must use either Linux, MacOS or Windows to build the crate."
+        ),
+    };
+    if target_arch == "x86_64" && target_os == "android" && build_os == "windows" {
+        let android_ndk_home = env::var("ANDROID_NDK_HOME").expect("ANDROID_NDK_HOME not set");
+        let clang_version =
+            env::var("NDK_CLANG_VERSION").unwrap_or_else(|_| DEFAULT_CLANG_VERSION.to_owned());
+        let linux_x86_64_lib_dir = format!(
+            "toolchains/llvm/prebuilt/{build_os}-x86_64/lib/clang/{clang_version}/lib/linux/"
+        );
+        let linkpath = format!("{android_ndk_home}/{linux_x86_64_lib_dir}");
+        if Path::new(&linkpath).exists() {
+            println!("cargo:rustc-link-search={android_ndk_home}/{linux_x86_64_lib_dir}");
+            println!("cargo:rustc-link-lib=static=clang_rt.builtins-x86_64-android");
+        } else {
+            panic!("Path {linkpath} not exists");
+        }
+    }
+}
 
 fn main() {
     // There are articles on internet suggest `.git/HEAD` is enough, which I
@@ -37,4 +71,6 @@ fn main() {
         `flutter_rust_bridge_codegen generate` to get a real one."
         );
     }
+
+    setup_x86_64_android_workaround();
 }


### PR DESCRIPTION
This is basically bring back #69 .
It seems we still need this, but I limited it to windows for now because only windows users are reporting this. 