### PR TITLE
Notification for unexpected close on iOS

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -30,6 +30,7 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+        coreLibraryDesugaringEnabled true
     }
 
     kotlinOptions {
@@ -48,6 +49,7 @@ android {
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
+        multiDexEnabled true
     }
 
     buildTypes {
@@ -63,4 +65,6 @@ flutter {
     source '../..'
 }
 
-dependencies {}
+dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
+}

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -36,6 +36,8 @@ PODS:
     - DKImagePickerController/PhotoGallery
     - Flutter
   - Flutter (1.0.0)
+  - flutter_local_notifications (0.0.1):
+    - Flutter
   - fluttertoast (0.0.2):
     - Flutter
     - Toast
@@ -79,6 +81,7 @@ DEPENDENCIES:
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Flutter (from `Flutter`)
+  - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/ios`)
   - mapbox_maps_flutter (from `.symlinks/plugins/mapbox_maps_flutter/ios`)
@@ -109,6 +112,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/file_picker/ios"
   Flutter:
     :path: Flutter
+  flutter_local_notifications:
+    :path: ".symlinks/plugins/flutter_local_notifications/ios"
   fluttertoast:
     :path: ".symlinks/plugins/fluttertoast/ios"
   geolocator_apple:
@@ -136,6 +141,7 @@ SPEC CHECKSUMS:
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
   file_picker: 09aa5ec1ab24135ccd7a1621c46c84134bfd6655
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
   fluttertoast: e9a18c7be5413da53898f660530c56f35edfba9c
   geolocator_apple: 6cbaf322953988e009e5ecb481f07efece75c450
   mapbox_maps_flutter: 943324063065b4ef15e146be95ed87f5bae1a6ba

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -7,6 +7,10 @@ import Flutter
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    if #available(iOS 10.0, *) {
+      UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
+    }
+
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/app/lib/gps_recording_state.dart
+++ b/app/lib/gps_recording_state.dart
@@ -75,7 +75,7 @@ class _UnexpectedCloseNotifier {
 
   _cancelNotification() async {
     if (_alertScheduled) {
-      var notification = NotificationHandler.instance();
+      var notification = NotificationHandler.instance;
       await notification.flutterLocalNotificationsPlugin
           .cancel(notification.alertUnexpectedClosedId);
       _alertScheduled = false;
@@ -83,14 +83,13 @@ class _UnexpectedCloseNotifier {
   }
 
   _scheduleNotification() async {
-    var notification = NotificationHandler.instance();
+    var notification = NotificationHandler.instance;
     await notification.flutterLocalNotificationsPlugin.zonedSchedule(
       notification.alertUnexpectedClosedId,
       'Recording was unexpectedly stopped',
       'Recording was unexpectedly stopped, please restart the app.',
       tz.TZDateTime.now(tz.local).add(const Duration(seconds: 5)),
       notification.alertPlatformChannelSpecifics,
-      androidScheduleMode: AndroidScheduleMode.inexact,
       uiLocalNotificationDateInterpretation:
           UILocalNotificationDateInterpretation.absoluteTime,
     );
@@ -152,7 +151,7 @@ class GpsRecordingState extends ChangeNotifier {
         distanceFilter: distanceFilter,
       );
     }
-    _UnexpectedCloseNotifier.start();
+    _UnexpectedCloseNotifier.start(this);
     _initState();
   }
 

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -18,7 +18,6 @@ import 'package:memolanes/src/rust/frb_generated.dart';
 import 'package:provider/provider.dart';
 import 'package:badges/badges.dart' as badges;
 import 'package:timezone/data/latest.dart' as tz;
-import 'package:timezone/timezone.dart' as tz;
 
 void delayedInit(UpdateNotifier updateNotifier) {
   Future.delayed(const Duration(milliseconds: 2000), () async {

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -68,6 +68,7 @@ void main() async {
   // This is required since we are doing things before calling `runApp`.
   WidgetsFlutterBinding.ensureInitialized();
   // TODO: Consider using `flutter_native_splash`
+  tz.initializeTimeZones();
   await RustLib.init();
   await api.init(
       tempDir: (await getTemporaryDirectory()).path,
@@ -78,7 +79,6 @@ void main() async {
   delayedInit(updateNotifier);
   await NotificationHandler.instance.initialize();
   var gpsRecordingState = GpsRecordingState();
-  tz.initializeTimeZones();
   runApp(
     MultiProvider(
       providers: [

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:memolanes/notification_handler.dart';
 import 'package:memolanes/time_machine.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path_provider/path_provider.dart';
@@ -16,6 +17,8 @@ import 'package:memolanes/src/rust/api/api.dart' as api;
 import 'package:memolanes/src/rust/frb_generated.dart';
 import 'package:provider/provider.dart';
 import 'package:badges/badges.dart' as badges;
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
 
 void delayedInit(UpdateNotifier updateNotifier) {
   Future.delayed(const Duration(milliseconds: 2000), () async {
@@ -74,7 +77,9 @@ void main() async {
       cacheDir: (await getApplicationCacheDirectory()).path);
   var updateNotifier = UpdateNotifier();
   delayedInit(updateNotifier);
+  await NotificationHandler.instance().initialize();
   var gpsRecordingState = GpsRecordingState();
+  tz.initializeTimeZones();
   runApp(
     MultiProvider(
       providers: [
@@ -186,6 +191,10 @@ class _MyHomePageState extends State<MyHomePage> {
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.start,
                   children: <Widget>[
+                    ElevatedButton(
+                      onPressed: _showNotification,
+                      child: Text("Show Notification"),
+                    ),
                     GPSPage(),
                     const Expanded(
                       child: MapUiBody(),
@@ -201,4 +210,6 @@ class _MyHomePageState extends State<MyHomePage> {
           )),
     );
   }
+
+  Future<void> _showNotification() async {}
 }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -77,7 +77,7 @@ void main() async {
       cacheDir: (await getApplicationCacheDirectory()).path);
   var updateNotifier = UpdateNotifier();
   delayedInit(updateNotifier);
-  await NotificationHandler.instance().initialize();
+  await NotificationHandler.instance.initialize();
   var gpsRecordingState = GpsRecordingState();
   tz.initializeTimeZones();
   runApp(
@@ -191,10 +191,6 @@ class _MyHomePageState extends State<MyHomePage> {
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.start,
                   children: <Widget>[
-                    ElevatedButton(
-                      onPressed: _showNotification,
-                      child: Text("Show Notification"),
-                    ),
                     GPSPage(),
                     const Expanded(
                       child: MapUiBody(),
@@ -210,6 +206,4 @@ class _MyHomePageState extends State<MyHomePage> {
           )),
     );
   }
-
-  Future<void> _showNotification() async {}
 }

--- a/app/lib/notification_handler.dart
+++ b/app/lib/notification_handler.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+class NotificationHandler {
+  static NotificationHandler? _instance;
+
+  factory NotificationHandler.instance() {
+    _instance ??= NotificationHandler._();
+    return _instance!;
+  }
+
+  FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
+      FlutterLocalNotificationsPlugin();
+
+  // NOTE: we actually don't send this on Android.
+  // See `_UnexpectedCloseNotifier` for more detial.
+  NotificationDetails alertPlatformChannelSpecifics =
+      const NotificationDetails();
+  int alertUnexpectedClosedId = 100;
+
+  NotificationHandler._();
+
+  initialize() async {
+    var initializationSettingsAndroid =
+        const AndroidInitializationSettings('@mipmap/ic_launcher');
+    var initializationSettingsIOS = const DarwinInitializationSettings();
+    var initializationSettings = InitializationSettings(
+        android: initializationSettingsAndroid, iOS: initializationSettingsIOS);
+    await flutterLocalNotificationsPlugin.initialize(initializationSettings);
+  }
+}

--- a/app/lib/notification_handler.dart
+++ b/app/lib/notification_handler.dart
@@ -1,12 +1,7 @@
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 class NotificationHandler {
-  static NotificationHandler? _instance;
-
-  factory NotificationHandler.instance() {
-    _instance ??= NotificationHandler._();
-    return _instance!;
-  }
+  static final NotificationHandler instance = NotificationHandler._();
 
   FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
       FlutterLocalNotificationsPlugin();

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -230,6 +230,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.6"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "365c771ac3b0e58845f39ec6deebc76e3276aa9922b0cc60840712094d9047ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.10"
   device_info_plus:
     dependency: "direct main"
     description:
@@ -307,6 +315,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "49eeef364fddb71515bc78d5a8c51435a68bccd6e4d68e25a942c5e47761ae71"
+      url: "https://pub.dev"
+    source: hosted
+    version: "17.2.3"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: c49bd06165cad9beeb79090b18cd1eb0296f4bf4b23b84426e37dd7c027fc3af
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.1"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "85f8d07fe708c1bdcf45037f2c0109753b26ae077e9d9e899d55971711a4ea66"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -734,6 +766,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.2"
   platform:
     dependency: transitive
     description:
@@ -986,6 +1026,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.2"
+  timezone:
+    dependency: "direct main"
+    description:
+      name: timezone
+      sha256: "2236ec079a174ce07434e89fcd3fcda430025eb7692244139a9cf54fdcf1fc7d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
   timing:
     dependency: transitive
     description:
@@ -1170,6 +1218,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
   yaml:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -58,6 +58,8 @@ dependencies:
   url_launcher: ^6.3.0
   badges: ^3.1.2
   shared_preferences: ^2.2.3
+  flutter_local_notifications: ^17.2.3
+  timezone: ^0.9.4
 
 dependency_overrides:
   geolocator_android:

--- a/app/rust_builder/android/build.gradle
+++ b/app/rust_builder/android/build.gradle
@@ -31,7 +31,7 @@ android {
 
     // Bumping the plugin compileSdkVersion requires all clients of this plugin
     // to bump the version in their app.
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     // Use the NDK version
     // declared in /android/app/build.gradle file of the Flutter project.


### PR DESCRIPTION
Notify the user that the recording was unexpectedly stopped on iOS.
On Android, this does not work, and we achive this by using foreground task.
On iOS we rely on this to make sure user will be notified when the app is killed during recording.