### PR TITLE
Journey bitmap operations tweak

### DIFF
--- a/app/journey_kernel/src/journey_bitmap.rs
+++ b/app/journey_kernel/src/journey_bitmap.rs
@@ -147,20 +147,20 @@ impl JourneyBitmap {
 
     pub fn difference(&mut self, other_journey_bitmap: &JourneyBitmap) {
         for (tile_key, other_tile) in &other_journey_bitmap.tiles {
-            if let Some(tile) = self.tiles.get_mut(&tile_key) {
+            if let Some(tile) = self.tiles.get_mut(tile_key) {
                 for (block_key, other_block) in &other_tile.blocks {
-                    if let Some(block) = tile.blocks.get_mut(&block_key) {
+                    if let Some(block) = tile.blocks.get_mut(block_key) {
                         for i in 0..other_block.data.len() {
                             block.data[i] = block.data[i].bitand(other_block.data[i].not());
                         }
                         if block.is_empty() {
-                            tile.blocks.remove(&block_key);
+                            tile.blocks.remove(block_key);
                         }
                     }
                 }
 
                 if tile.blocks.is_empty() {
-                    self.tiles.remove(&tile_key);
+                    self.tiles.remove(tile_key);
                 }
             }
         }

--- a/app/journey_kernel/src/journey_bitmap.rs
+++ b/app/journey_kernel/src/journey_bitmap.rs
@@ -145,10 +145,10 @@ impl JourneyBitmap {
         }
     }
 
-    pub fn difference(&mut self, other_journey_bitmap: JourneyBitmap) {
-        for (tile_key, other_tile) in other_journey_bitmap.tiles {
+    pub fn difference(&mut self, other_journey_bitmap: &JourneyBitmap) {
+        for (tile_key, other_tile) in &other_journey_bitmap.tiles {
             if let Some(tile) = self.tiles.get_mut(&tile_key) {
-                for (block_key, other_block) in other_tile.blocks {
+                for (block_key, other_block) in &other_tile.blocks {
                     if let Some(block) = tile.blocks.get_mut(&block_key) {
                         for i in 0..other_block.data.len() {
                             block.data[i] = block.data[i].bitand(other_block.data[i].not());
@@ -166,7 +166,7 @@ impl JourneyBitmap {
         }
     }
 
-    pub fn intersection(&mut self, other_journey_bitmap: JourneyBitmap) {
+    pub fn intersection(&mut self, other_journey_bitmap: &JourneyBitmap) {
         self.tiles.retain(
             |tile_key, tile| match other_journey_bitmap.tiles.get(tile_key) {
                 None => false,

--- a/app/rust/tests/journey_bitmap.rs
+++ b/app/rust/tests/journey_bitmap.rs
@@ -82,7 +82,7 @@ fn intersection_and_difference() {
     {
         let mut line4 = JourneyBitmap::new();
         draw_line4(&mut line4);
-        rhs.intersection(line4);
+        rhs.intersection(&line4);
     }
 
     let mut lhs = JourneyBitmap::new();
@@ -92,8 +92,8 @@ fn intersection_and_difference() {
         draw_line3(&mut line3);
         let mut line4 = JourneyBitmap::new();
         draw_line4(&mut line4);
-        line3.difference(line4);
-        lhs.difference(line3);
+        line3.difference(&line4);
+        lhs.difference(&line3);
     }
 
     assert_ne!(lhs, JourneyBitmap::new());
@@ -108,7 +108,7 @@ fn intersection_and_difference_produce_empty() {
         draw_line1(&mut journey_bitmap);
         let mut line1 = JourneyBitmap::new();
         draw_line1(&mut line1);
-        journey_bitmap.difference(line1);
+        journey_bitmap.difference(&line1);
         assert_eq!(journey_bitmap, JourneyBitmap::new());
     }
     {
@@ -117,7 +117,7 @@ fn intersection_and_difference_produce_empty() {
         draw_line1(&mut journey_bitmap);
         let mut line2 = JourneyBitmap::new();
         draw_line2(&mut line2);
-        journey_bitmap.intersection(line2);
+        journey_bitmap.intersection(&line2);
         assert_eq!(journey_bitmap, JourneyBitmap::new());
     }
 }


### PR DESCRIPTION
Basically, for both `difference` and `intersection`, taking the ownership is unnecessary. These two are needed for building memolanes export feature in fog machine.