### PR TITLE
Fix precision issue with journey bitmap area computation

### DIFF
--- a/app/analysis_options.yaml
+++ b/app/analysis_options.yaml
@@ -25,7 +25,10 @@ linter:
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
   
 analyzer:
-  exclude: [rust_builder/**]
+  exclude: 
+    - 'rust_builder/**'
+    - 'lib/src/rust/**'
+
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/app/rust/src/journey_area_utils.rs
+++ b/app/rust/src/journey_area_utils.rs
@@ -10,7 +10,7 @@ const EARTH_RADIUS: f64 = 6371000.0; // unit: meter
 // block has better efficiency and accuracy compared to simple interation and other methods.
 // codes for different calculating methods can be found here:
 // https://github.com/TimRen01/TimRen01_repo/tree/compare_method_calculate_area_by_journey
-pub fn compute_journey_bitmap_area(journey_bitmap: &JourneyBitmap) -> f64 {
+pub fn compute_journey_bitmap_area(journey_bitmap: &JourneyBitmap) -> u64 {
     let total_area: f64 = journey_bitmap
         .tiles
         .iter()
@@ -60,5 +60,6 @@ pub fn compute_journey_bitmap_area(journey_bitmap: &JourneyBitmap) -> f64 {
             })
         })
         .sum();
-    total_area
+    // we don't have that much precision in the journey bitmap anyway
+    total_area.round() as u64
 }

--- a/app/rust/tests/journey_area_utils.rs
+++ b/app/rust/tests/journey_area_utils.rs
@@ -1,13 +1,11 @@
 pub mod test_utils;
 
 use memolanes_core::{import_data, journey_area_utils};
-#[macro_use]
-extern crate assert_float_eq;
 
 #[test]
 fn test_compute_journey_bitmap_area() {
     let (bitmap_import, _warnings) =
         import_data::load_fow_sync_data("./tests/data/fow_1.zip").unwrap();
     let calculated_area = journey_area_utils::compute_journey_bitmap_area(&bitmap_import);
-    assert_f64_near!(calculated_area, 3035669.991974149); // area unit: m^2
+    assert_eq!(calculated_area, 3035670); // area unit: m^2
 }


### PR DESCRIPTION
Basically we don't need f64 at all in the final result, our input (journey bitmap) is already on ~10m level.