### PR TITLE
Reset preprocessor state at appropriate time

### DIFF
--- a/app/rust/src/gps_processor.rs
+++ b/app/rust/src/gps_processor.rs
@@ -141,10 +141,17 @@ impl BadDataDetector {
                 if timestamp_ms <= *prev_timestamp_ms {
                     return true;
                 }
+                let time_span_in_sec = (timestamp_ms - prev_timestamp_ms) as f32 / 1000.0;
+
+                // reset the state if the time span is too long, otherwise
+                if time_span_in_sec >= 10. {
+                    self.timestamp_ms_and_point = None;
+                    self.speed = None;
+                    return false;
+                }
 
                 // computing the speed by ourself instead of using the speed from `RawData`.
                 let distance_m = curr_data.point.haversine_distance(prev_point) as f32;
-                let time_span_in_sec = (timestamp_ms - prev_timestamp_ms) as f32 / 1000.0;
                 let speed = distance_m / time_span_in_sec;
 
                 if let Some(last_speed) = self.speed {

--- a/app/rust/src/gps_processor.rs
+++ b/app/rust/src/gps_processor.rs
@@ -143,7 +143,9 @@ impl BadDataDetector {
                 }
                 let time_span_in_sec = (timestamp_ms - prev_timestamp_ms) as f32 / 1000.0;
 
-                // reset the state if the time span is too long, otherwise
+                // reset the state if the time span is too long, otherwise we
+                // might have a very outdated speed value. In general, a lot of 
+                // assumptions here does not hold if the time span is too long.
                 if time_span_in_sec >= 10. {
                     self.timestamp_ms_and_point = None;
                     self.speed = None;

--- a/app/rust/src/gps_processor.rs
+++ b/app/rust/src/gps_processor.rs
@@ -144,8 +144,8 @@ impl BadDataDetector {
                 let time_span_in_sec = (timestamp_ms - prev_timestamp_ms) as f32 / 1000.0;
 
                 // reset the state if the time span is too long, otherwise we
-                // might have a very outdated speed value. In general, a lot of 
-                // assumptions here does not hold if the time span is too long.
+                // might have a very outdated speed value. In general, a lot of
+                // assumptions here do not hold if the time span is too long.
                 if time_span_in_sec >= 10. {
                     self.timestamp_ms_and_point = None;
                     self.speed = None;

--- a/app/rust/tests/gps_preprocessor.rs
+++ b/app/rust/tests/gps_preprocessor.rs
@@ -166,17 +166,17 @@ fn run_though_test_data(name: &str) -> HashMap<ProcessResult, i32> {
 #[test]
 fn run_though_test_data_shanghai() {
     let counter = run_though_test_data("shanghai");
-    assert_eq!(counter[&ProcessResult::NewSegment], 12);
-    assert_eq!(counter[&ProcessResult::Append], 2955);
-    assert_eq!(counter[&ProcessResult::Ignore], 651);
+    assert_eq!(counter[&ProcessResult::NewSegment], 11);
+    assert_eq!(counter[&ProcessResult::Append], 2959);
+    assert_eq!(counter[&ProcessResult::Ignore], 648);
 }
 
 #[test]
 fn run_though_test_data_shenzhen_stationary() {
     let counter = run_though_test_data("shenzhen_stationary");
     assert_eq!(counter[&ProcessResult::NewSegment], 8);
-    assert_eq!(counter[&ProcessResult::Append], 441);
-    assert_eq!(counter[&ProcessResult::Ignore], 6281);
+    assert_eq!(counter[&ProcessResult::Append], 443);
+    assert_eq!(counter[&ProcessResult::Ignore], 6279);
 }
 
 #[test]

--- a/app/rust/tests/image_hashes.lock
+++ b/app/rust/tests/image_hashes.lock
@@ -1,10 +1,10 @@
 {
   "end_to_end_basic_0": "2e7e353be8a72864dd53e73f0839ea5bd54136603cf6cfadbf5f9929b641151e",
-  "end_to_end_basic_1": "822a4b996cbbe771f215e89b7184469f1a8d7b78103c072f53803de7a68ff92b",
+  "end_to_end_basic_1": "e43bb76af6ac69daf881625b0a3a557a79d4d791c6512807104f63976c4da1ba",
   "journey_bitmap_add_line_cross_antimeridian": "de3e6516a141155a9e0befb592da33beaa37d3abec30e24666fe98109b91a567",
   "journey_bitmap_merge_with_render": "0a8402ab68a8e24ad08061cfed455b0ac781c25f53dbe77850f97658984b83a2",
   "journey_bitmap_vector_to_bitmap_laojunshan": "8651a7d51f1f7710a6f6cbf961ebad6664768e5bfbe7101471439eaa71597ccb",
   "journey_bitmap_vector_to_bitmap_nelson_to_wharariki_beach": "75c93ac303638bbd092db10968dbb604477631aca4247fc1700368ec86309c57",
-  "journey_bitmap_vector_to_bitmap_shenzhen_stationary": "5f2071dd800780b628ab3f1970eb3311d5595c3e7a10fc3527a3ecc9f302031f",
+  "journey_bitmap_vector_to_bitmap_shenzhen_stationary": "40169966a56954659ac1ea8b2cebe364efa4668160f44bd3e7717c8874a8dd6d",
   "map_renderer_basic": "d124d8e2a56dd15920b726ffc6f6f79be13118fa0a10ed2f2cc9a6cd0bd6615f"
 }


### PR DESCRIPTION
1. When a journey is finalized, we should reset the whole preprocessor state.
2. After a little while without any gps data, we should reset the bad data detector state.

Manually inspected the test diff, they all look reasonable.
