### PR TITLE
Fix server fault when TileBuffer range out-of-bound

### DIFF
--- a/app/rust/benches/rendering.rs
+++ b/app/rust/benches/rendering.rs
@@ -47,7 +47,7 @@ fn tile_buffer_creation_benchmarks(c: &mut Criterion) {
                             *width,
                             *height,
                             **buffer_size_power,
-                        ))
+                        ).unwrap())
                     })
                 },
             );


### PR DESCRIPTION
- Updated the `from_journey_bitmap` method to return a Result type, allowing for error handling during TileBuffer creation.
- Added validation checks for width, height, zoom level, and buffer size power to prevent invalid configurations and potential overflows.
- Implemented error logging in the `serve_journey_tile_range` function to handle and report creation and serialization errors gracefully.
- Adjusted benchmarks to accommodate the new Result type in TileBuffer creation.