### PR TITLE
Handle slow start up better

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -24,6 +24,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'logger.dart';
 
 GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+bool mainMapInitialized = false;
 
 void delayedInit(UpdateNotifier updateNotifier) {
   Future.delayed(const Duration(milliseconds: 4000), () async {
@@ -186,6 +187,17 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> {
   int _selectedIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!mainMapInitialized) {
+        mainMapInitialized = true;
+        showLoadingDialog(context: context, asyncTask: api.initMainMap());
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/utils.dart
+++ b/app/lib/utils.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:memolanes/logger.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 
 import 'component/common_dialog.dart';

--- a/app/lib/utils.dart
+++ b/app/lib/utils.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:memolanes/logger.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 
 import 'component/common_dialog.dart';
@@ -58,7 +59,15 @@ Future<T> showLoadingDialog<T>({
   required BuildContext context,
   required Future<T> asyncTask,
 }) async {
-  if (!context.mounted) return Future.value();
+  var taskCompleteEarly = false;
+  asyncTask.whenComplete(() {
+    taskCompleteEarly = true;
+  });
+
+  // Do not show the loading dialog if the task is fast
+  await Future.delayed(const Duration(milliseconds: 200));
+  if (taskCompleteEarly) return asyncTask;
+  if (!context.mounted) return asyncTask;
 
   showDialog(
     context: context,


### PR DESCRIPTION
Right now we load the main journy bitmap as part of start up. This can be fairly slow, especially when we lost the cache (after an upgrade?). This feature is a small workaround to make it slightly better. There are still a lot we could improve.