### PR TITLE
Fix file sharing on ios 26

### DIFF
--- a/app/lib/body/settings/raw_data_page.dart
+++ b/app/lib/body/settings/raw_data_page.dart
@@ -4,7 +4,6 @@ import 'package:memolanes/common/component/tiles/label_tile.dart';
 import 'package:memolanes/common/utils.dart';
 import 'package:memolanes/src/rust/api/api.dart';
 import 'package:memolanes/src/rust/storage.dart';
-import 'package:share_plus/share_plus.dart';
 
 class RawDataSwitch extends StatefulWidget {
   const RawDataSwitch({super.key});
@@ -88,9 +87,7 @@ class _RawDataPage extends State<RawDataPage> {
                   leading: const Icon(Icons.description),
                   title: Text(item.name),
                   onTap: () {
-                    SharePlus.instance.share(
-                      ShareParams(files: [XFile(item.path)]),
-                    );
+                    showCommonExport(context, item.path, deleteFile: false);
                   },
                   trailing: ElevatedButton(
                     onPressed: () async {

--- a/app/lib/common/component/common_export.dart
+++ b/app/lib/common/component/common_export.dart
@@ -9,11 +9,24 @@ import 'package:share_plus/share_plus.dart';
 
 class CommonExport extends StatefulWidget {
   final String filePath;
+  final Rect outerSharePositionOrigin;
 
-  const CommonExport({super.key, required this.filePath});
+  const CommonExport(
+      {super.key,
+      required this.filePath,
+      required this.outerSharePositionOrigin});
 
   @override
   State<CommonExport> createState() => _CommonExportState();
+}
+
+Rect computeSharePositionOrigin(BuildContext context) {
+  final box = context.findRenderObject() as RenderBox?;
+  if (box == null) {
+    return Rect.zero;
+  } else {
+    return box.localToGlobal(Offset.zero) & box.size;
+  }
 }
 
 class _CommonExportState extends State<CommonExport> {
@@ -24,16 +37,17 @@ class _CommonExportState extends State<CommonExport> {
     super.initState();
 
     if (Platform.isIOS) {
-      _shareFile();
+      _shareFile(widget.outerSharePositionOrigin);
     } else {
       _showExportDialog = true;
     }
   }
 
-  Future<void> _shareFile() async {
-    await SharePlus.instance.share(
-      ShareParams(files: [XFile(widget.filePath)]),
-    );
+  Future<void> _shareFile(Rect sharePositionOrigin) async {
+    await SharePlus.instance.share(ShareParams(
+      files: [XFile(widget.filePath)],
+      sharePositionOrigin: sharePositionOrigin,
+    ));
     if (!mounted) return;
     Navigator.of(context).pop();
   }
@@ -82,7 +96,9 @@ class _CommonExportState extends State<CommonExport> {
           _buildIconButton(
             icon: FontAwesomeIcons.shareFromSquare,
             label: context.tr("common.share"),
-            onPressed: _shareFile,
+            onPressed: () {
+              _shareFile(computeSharePositionOrigin(context));
+            },
           ),
         ],
       ),

--- a/app/lib/common/utils.dart
+++ b/app/lib/common/utils.dart
@@ -112,10 +112,12 @@ Future<T> showLoadingDialog<T>({
 
 Future<bool> showCommonExport(BuildContext context, String filePath,
     {bool deleteFile = false}) async {
+  final outerSharePositionOrigin = computeSharePositionOrigin(context);
   final dialogResult = await showDialog<bool>(
     context: context,
     barrierDismissible: false,
-    builder: (_) => CommonExport(filePath: filePath),
+    builder: (_) => CommonExport(
+        filePath: filePath, outerSharePositionOrigin: outerSharePositionOrigin),
   );
 
   if (deleteFile) {


### PR DESCRIPTION
We didn't pass in `sharePositionOrigin`. It used to be only required on iPad (I guess we never do this on iPad so never notice it breaking), now it is also required on iPhone since ios 26.