### PR TITLE
Refactor map integration to use MapLibre GL instead of Mapbox GL

### DIFF
--- a/app/journey_kernel/package.json
+++ b/app/journey_kernel/package.json
@@ -9,7 +9,8 @@
     "check-format": "prettier --check \"**/*.{js,jsx,ts,tsx,html}\""
   },
   "dependencies": {
-    "mapbox-gl": "3.14.0"
+    "maplibre-gl": "^5.7.3",
+    "maplibregl-mapbox-request-transformer": "^0.0.3"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "^1.7.0",
@@ -17,10 +18,10 @@
     "css-loader": "^6.10.0",
     "html-webpack-plugin": "^5.6.4",
     "prettier": "^3.6.2",
+    "rimraf": "^5.0.0",
     "style-loader": "^3.3.4",
     "webpack": "^5.101.3",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.2.2",
-    "rimraf": "^5.0.0"
+    "webpack-dev-server": "^5.2.2"
   }
 }

--- a/app/journey_kernel/static/journey-canvas-layer.js
+++ b/app/journey_kernel/static/journey-canvas-layer.js
@@ -110,10 +110,22 @@ export class JourneyCanvasLayer {
       }
     }
 
-    const nw = tileXYToLngLat([left, top], z);
-    const ne = tileXYToLngLat([right, top], z);
-    const se = tileXYToLngLat([right, bottom], z);
-    const sw = tileXYToLngLat([left, bottom], z);
+    // This is a workaround for a maplibre 5.7.3 bug (or feature).
+    //  for a map view of multi-worldview (map wrap arounds and lng may be out of -180 - 180 range), 
+    //  it has a strict limit that the centor of the canvas fall into the half-open [-180, 180) range,
+    //  or equivalently, the centor's mercator coordinate x must fall in [0, 1) range. 
+    //  but for our codes, in border case, the centor's mercator coordinate x may be 1.
+    //  so we multiply both left and right x by 0.999999 to make it fall into the [0, 1) range.
+    // More info can be found at the calling stack referenced below,
+    //  https://github.com/maplibre/maplibre-gl-js/blob/8895e414984a6348a1260ed986a0d2d7753367a8/src/source/image_source.ts#L228
+    //  https://github.com/maplibre/maplibre-gl-js/blob/8895e414984a6348a1260ed986a0d2d7753367a8/src/source/image_source.ts#L350
+    //  https://github.com/maplibre/maplibre-gl-js/blob/08fce0cfbf28f4da2cde60025588a8cb9323c9fe/src/source/tile_id.ts#L23
+    const almost = (x) => x * 0.999999;
+
+    const nw = tileXYToLngLat([almost(left), top], z);
+    const ne = tileXYToLngLat([almost(right), top], z);
+    const se = tileXYToLngLat([almost(right), bottom], z);
+    const sw = tileXYToLngLat([almost(left), bottom], z);
 
     const mainCanvasSource = this.map.getSource("main-canvas-source");
     mainCanvasSource?.setCoordinates([nw, ne, se, sw]);

--- a/app/journey_kernel/static/utils.js
+++ b/app/journey_kernel/static/utils.js
@@ -48,7 +48,8 @@ export function getViewportTileRange(map) {
 
   // Calculate the minimum x and y coordinates
   const x = Math.min(swX, neX);
-  const y = Math.min(neY, swY);
+  // for maplibre, the calculated y may be out of range, we need to crop is accordingly
+  const y = Math.min(Math.max(0, Math.min(neY, swY)), (1 << z) - 1);
 
   // Calculate the width and height
   const w = Math.max(1, Math.abs(neX - swX) + 1);

--- a/app/lib/common/component/base_map_webview.dart
+++ b/app/lib/common/component/base_map_webview.dart
@@ -243,6 +243,11 @@ class BaseMapWebviewState extends State<BaseMapWebview> {
 
   Future<void> _injectApiEndpoint() async {
     final accessKey = api.getMapboxAccessToken();
+
+    // TODO: we may let user to choose base map providers.
+    final mapStyle = "https://tiles.openfreemap.org/styles/liberty";
+    // final mapStyle = "mapbox://styles/mapbox/streets-v12";
+
     final journeyId = widget.mapRendererProxy.getJourneyId();
 
     debugPrint('Injecting access key: $accessKey');
@@ -262,7 +267,8 @@ class BaseMapWebviewState extends State<BaseMapWebview> {
       window.EXTERNAL_PARAMS = {
         cgi_endpoint: "flutter://TileProviderChannel",
         journey_id: "$journeyId",
-        render: "gl",
+        render: "canvas",
+        map_style: "$mapStyle",
         access_key: "$accessKey",
         lng: $lngParam,
         lat: $latParam,


### PR DESCRIPTION
- Updated dependencies in package.json to include maplibre-gl and maplibregl-mapbox-request-transformer.
- Replaced mapbox-gl imports with maplibre-gl in index.js and journey-canvas-layer.js.
- Adjusted map initialization and rendering logic to accommodate MapLibre's API.
- Implemented a transformation function for Mapbox URLs to ensure compatibility with MapLibre.
- Updated utility functions to handle coordinate calculations specific to MapLibre's requirements.