### PR TITLE
Fix android gradle ndk abiFilters

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -50,6 +50,7 @@ android {
         getByName("debug") {
             signingConfig = signingConfigs.getByName("debug")
             ndk {
+                abiFilters.clear()
                 abiFilters += listOf("arm64-v8a", "x86_64")
             }
         }
@@ -62,6 +63,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             )
             ndk {
+                abiFilters.clear()
                 // noinspection ChromeOsAbiSupport
                 abiFilters += "arm64-v8a"
             }


### PR DESCRIPTION
Starting in Flutter 3.35, the Flutter Gradle Plugin automatically sets [abiFilters](https://developer.android.com/reference/tools/gradle-api/8.7/com/android/build/api/dsl/Ndk#abiFilters()) for Android builds to prevent the inclusion of unsupported architectures in release APKs. This change can break custom abiFilters specified in your app's build.gradle file.

https://docs.flutter.dev/release/breaking-changes/default-abi-filters-android