### PR TITLE
Drop empty tiles and blocks

### DIFF
--- a/app/rust/src/import_data.rs
+++ b/app/rust/src/import_data.rs
@@ -88,10 +88,14 @@ fn parse_fow_bitmap_file<R: Read>(
                     let mut bitmap: [u8; BLOCK_BITMAP_SIZE] = [0; BLOCK_BITMAP_SIZE];
                     bitmap.copy_from_slice(&data[start_offset..end_offset]);
                     let block = Block::new_with_data(bitmap);
-                    tile.set(&block_key, block);
+                    if !block.is_empty() {
+                        tile.set(&block_key, block);
+                    }
                 }
             }
-            journey_bitmap.insert_tile(&TileKey::new(id.x, id.y), tile);
+            if !tile.is_empty() {
+                journey_bitmap.insert_tile(&TileKey::new(id.x, id.y), tile);
+            }
         }
     }
     Ok(())

--- a/app/rust/src/journey_bitmap.rs
+++ b/app/rust/src/journey_bitmap.rs
@@ -126,8 +126,20 @@ impl JourneyBitmap {
     /// Validate that all serialized tiles can be deserialized successfully.
     /// This is necessary when importing data. Other parts of the code assume
     /// deserialization will always succeed.
-    pub fn validate(&self) -> anyhow::Result<()> {
+    /// We also try to remove empty tiles and blocks here. This is not strictly
+    /// necessary, but we are aware that some users have "invalid" data like this
+    /// which are created by old versions of this app.
+    pub fn validate(&mut self) -> anyhow::Result<()> {
         // Actually nothing needs to be done here.
+        self.tiles.retain(|_, tile| {
+            for block in &mut tile.blocks {
+                if block.as_ref().is_some_and(|b| b.is_empty()) {
+                    *block = None;
+                }
+            }
+            !tile.is_empty()
+        });
+
         Ok(())
     }
 
@@ -677,7 +689,7 @@ impl Block {
         *self.mipmap.borrow_mut() = None;
     }
 
-    fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         for i in self.data {
             if i != 0 {
                 return false;
@@ -863,7 +875,7 @@ impl Block {
     }
 
     // x ∈ [0,63], y ∈ [0，63]
-    fn set_point(&mut self, x: u8, y: u8, val: bool) {
+    pub fn set_point(&mut self, x: u8, y: u8, val: bool) {
         if x > 63 || y > 63 {
             return;
         }

--- a/app/rust/src/journey_data.rs
+++ b/app/rust/src/journey_data.rs
@@ -137,7 +137,7 @@ pub fn deserialize_journey_bitmap<T: Read>(
         tiles_and_bytes.push((TileKey::new(tile_x, tile_y), tile_bytes));
     }
 
-    let journey_bitmap = JourneyBitmap::of_tile_bytes_without_validation(tiles_and_bytes)?;
+    let mut journey_bitmap = JourneyBitmap::of_tile_bytes_without_validation(tiles_and_bytes)?;
     if full_validation {
         journey_bitmap.validate()?;
     }

--- a/app/rust/tests/journey_bitmap.rs
+++ b/app/rust/tests/journey_bitmap.rs
@@ -3,8 +3,12 @@ use crate::test_utils::{
     draw_line1, draw_line2, draw_line3, draw_line4, END_LAT, END_LNG, START_LAT, START_LNG,
 };
 use memolanes_core::{
-    gps_processor::SegmentGapRule, import_data, journey_area_utils, journey_bitmap::JourneyBitmap,
-    journey_data::JourneyData, journey_header::JourneyType, renderer::MapRenderer,
+    gps_processor::SegmentGapRule,
+    import_data, journey_area_utils,
+    journey_bitmap::{Block, BlockKey, JourneyBitmap, Tile, TileKey},
+    journey_data::JourneyData,
+    journey_header::JourneyType,
+    renderer::MapRenderer,
 };
 
 #[test]
@@ -298,4 +302,36 @@ fn draw_line_with_width3() {
     let render_result =
         test_utils::render_map_overlay(&mut map_renderer, 13, 120.0, 70.01, 120.01, 70.0);
     test_utils::verify_image("draw_line_with_width3", &render_result.data);
+}
+
+#[test]
+fn validate_prunes_empty_blocks_and_tiles() {
+    let keep_key = TileKey::new(1, 2);
+    let drop_key = TileKey::new(3, 4);
+    let empty_block_key = BlockKey::from_x_y(0, 0);
+    let non_empty_block_key = BlockKey::from_x_y(0, 1);
+
+    let mut keep_tile = Tile::new();
+    keep_tile.set(&empty_block_key, Block::new());
+    let mut non_empty_block = Block::new();
+    non_empty_block.set_point(10, 10, true);
+    keep_tile.set(&non_empty_block_key, non_empty_block);
+
+    let mut drop_tile = Tile::new();
+    drop_tile.set(&empty_block_key, Block::new());
+
+    let mut bitmap = JourneyBitmap::of_tile_bytes_without_validation(vec![
+        (keep_key, keep_tile.serialize()),
+        (drop_key, drop_tile.serialize()),
+    ])
+    .unwrap();
+
+    bitmap.validate().unwrap();
+
+    assert!(bitmap.contains_tile(&keep_key));
+    assert!(!bitmap.contains_tile(&drop_key));
+
+    let keep_tile = bitmap.get_tile(&keep_key).expect("tile should remain");
+    assert!(keep_tile.get(&empty_block_key).is_none());
+    assert!(keep_tile.get(&non_empty_block_key).is_some());
 }


### PR DESCRIPTION
by the design of journey bitmap, we should have this. However, we noticed that there are users with this invalid journey bitmap because it was imported from fow data.