### PR TITLE
Add explored-area achievement read-model with an in-memory stat cache

### DIFF
--- a/app/lib/common/achievement_stats_store.dart
+++ b/app/lib/common/achievement_stats_store.dart
@@ -85,15 +85,15 @@ class AchievementStatsStore extends ChangeNotifier {
   }
 
   Future<AchievementAreaStats> _fetchAreaStats() async {
-    final areas = await achievement_api.getExploredAreaByLayer();
-    final byLayer = {
-      for (final area in areas) area.layer: area.areaM2.toDouble() / 1000000,
-    };
+    final areasByLayer = await achievement_api.getExploredAreaByLayer();
+    double km2For(AchievementLayer layer) {
+      return (areasByLayer[layer]?.toDouble() ?? 0) / 1000000;
+    }
 
     return AchievementAreaStats(
-      totalKm2: byLayer[AchievementLayer.all] ?? 0,
-      groundKm2: byLayer[AchievementLayer.default_] ?? 0,
-      flightKm2: byLayer[AchievementLayer.flight] ?? 0,
+      totalKm2: km2For(AchievementLayer.all),
+      groundKm2: km2For(AchievementLayer.default_),
+      flightKm2: km2For(AchievementLayer.flight),
     );
   }
 }

--- a/app/rust/src/achievement/explored_area.rs
+++ b/app/rust/src/achievement/explored_area.rs
@@ -1,0 +1,26 @@
+//! Explored-area read-model: total covered area (m²) per layer. Pure — depends
+//! only on the layer scope, storage, and the bitmap-area primitive.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+
+use super::scope::AchievementLayer;
+use crate::journey_area_utils::compute_journey_bitmap_area;
+use crate::storage::Storage;
+
+/// Explored area (m²) for each requested layer, read under one consistent
+/// journey snapshot so the layers cannot skew against each other.
+pub fn compute_explored_areas(
+    storage: &Storage,
+    layers: &[AchievementLayer],
+) -> Result<HashMap<AchievementLayer, u64>> {
+    storage.with_journey_snapshot(|snapshot| {
+        let mut out = HashMap::with_capacity(layers.len());
+        for &layer in layers {
+            let bitmap = snapshot.finalized_bitmap(&layer.to_layer_kind(), None)?;
+            out.insert(layer, compute_journey_bitmap_area(&bitmap, None));
+        }
+        Ok(out)
+    })
+}

--- a/app/rust/src/achievement/mod.rs
+++ b/app/rust/src/achievement/mod.rs
@@ -1,3 +1,6 @@
 //! Achievement statistics: explored-area and (in later slices)
 //! geo-entity coverage computed from journey data.
+pub mod explored_area;
+pub mod query;
 pub mod scope;
+pub mod stat_cache;

--- a/app/rust/src/achievement/query.rs
+++ b/app/rust/src/achievement/query.rs
@@ -1,0 +1,19 @@
+//! Achievement stat queries and typed results. Each stat is one
+//! `AchievementQuery` variant (used directly as the cache key), plus an
+//! `AchievementValue`; later stats extend these enums.
+
+use flutter_rust_bridge::frb;
+
+use super::scope::AchievementLayer;
+
+#[frb(ignore)]
+#[derive(PartialEq, Eq, Hash)]
+pub enum AchievementQuery {
+    ExploredAreaM2 { layer: AchievementLayer },
+}
+
+#[frb(ignore)]
+#[derive(Debug, Clone, PartialEq)]
+pub enum AchievementValue {
+    U64(u64),
+}

--- a/app/rust/src/achievement/stat_cache.rs
+++ b/app/rust/src/achievement/stat_cache.rs
@@ -1,0 +1,37 @@
+//! In-memory cache for achievement stats: one cell per `AchievementQuery`
+//! holding a typed `AchievementValue`, cleared on each journey-write commit.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use flutter_rust_bridge::frb;
+
+use super::query::{AchievementQuery, AchievementValue};
+
+#[frb(ignore)]
+#[derive(Default)]
+pub struct StatCache {
+    inner: Mutex<HashMap<AchievementQuery, AchievementValue>>,
+}
+
+impl StatCache {
+    pub fn get(&self, query: &AchievementQuery) -> Option<AchievementValue> {
+        self.inner
+            .lock()
+            .expect("stat cache poisoned")
+            .get(query)
+            .cloned()
+    }
+
+    pub fn put(&self, query: AchievementQuery, value: AchievementValue) {
+        self.inner
+            .lock()
+            .expect("stat cache poisoned")
+            .insert(query, value);
+    }
+
+    /// Evict all cached stats — called on each committed journey mutation.
+    pub fn invalidate(&self) {
+        self.inner.lock().expect("stat cache poisoned").clear();
+    }
+}

--- a/app/rust/src/api/achievement.rs
+++ b/app/rust/src/api/achievement.rs
@@ -1,50 +1,48 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
-use flutter_rust_bridge::frb;
 
+use crate::achievement::explored_area::compute_explored_areas;
+use crate::achievement::query::{AchievementQuery, AchievementValue};
 pub use crate::achievement::scope::AchievementLayer;
-use crate::journey_snapshot::JourneySnapshot;
 
-/// Total explored area for one layer in a single struct, for the
-/// "Default vs Flight vs All" comparison row.
-#[frb(non_opaque)]
-#[derive(Debug, Clone)]
-pub struct LayerArea {
-    pub layer: AchievementLayer,
-    pub area_m2: u64,
+/// Explored area (m²) per layer, via the stat cache. On any miss the WHOLE set
+/// is recomputed under one snapshot (not just the misses), so cached and fresh
+/// layers can't mix journey states (which would break `All >= Default`).
+fn cached_explored_areas(layers: &[AchievementLayer]) -> Result<HashMap<AchievementLayer, u64>> {
+    let state = crate::api::api::get();
+    let cache = &state.stat_cache;
+
+    let mut out = HashMap::with_capacity(layers.len());
+    for &layer in layers {
+        match cache.get(&AchievementQuery::ExploredAreaM2 { layer }) {
+            Some(AchievementValue::U64(area)) => {
+                out.insert(layer, area);
+            }
+            _ => {
+                let computed = compute_explored_areas(&state.storage, layers)?;
+                for (&layer, &area) in &computed {
+                    cache.put(
+                        AchievementQuery::ExploredAreaM2 { layer },
+                        AchievementValue::U64(area),
+                    );
+                }
+                return Ok(computed);
+            }
+        }
+    }
+    Ok(out)
 }
 
-/// Total explored area (m²) for one layer, from its merged finalized
-/// bitmap. Shared by the single-layer and per-layer queries so they
-/// always agree.
-fn layer_area_m2(snapshot: &JourneySnapshot, layer: AchievementLayer) -> Result<u64> {
-    let bitmap = snapshot.finalized_bitmap(&layer.to_layer_kind(), None)?;
-    Ok(crate::journey_area_utils::compute_journey_bitmap_area(
-        &bitmap, None,
-    ))
-}
-
-/// Total explored area for a single layer. Cheap: one cached-bitmap
-/// fetch and an area sum — no first_visited or worldview involvement.
+/// Explored area for a single layer.
 pub fn get_explored_area(layer: AchievementLayer) -> Result<u64> {
-    let storage = &crate::api::api::get().storage;
-    storage.with_journey_snapshot(|snapshot| layer_area_m2(snapshot, layer))
+    Ok(cached_explored_areas(&[layer])?
+        .get(&layer)
+        .copied()
+        .unwrap_or(0))
 }
 
-/// Total explored area per layer, read as ONE consistent snapshot so the
-/// rows can never contradict each other (e.g. `All` < `Default`). For the
-/// Default-vs-Flight-vs-All comparison; for a single layer use
-/// [`get_explored_area`].
-pub fn get_explored_area_by_layer() -> Result<Vec<LayerArea>> {
-    let storage = &crate::api::api::get().storage;
-    storage.with_journey_snapshot(|snapshot| {
-        AchievementLayer::ALL_LAYERS
-            .into_iter()
-            .map(|layer| {
-                Ok(LayerArea {
-                    layer,
-                    area_m2: layer_area_m2(snapshot, layer)?,
-                })
-            })
-            .collect()
-    })
+/// Explored area for every layer.
+pub fn get_explored_area_by_layer() -> Result<HashMap<AchievementLayer, u64>> {
+    cached_explored_areas(&AchievementLayer::ALL_LAYERS)
 }

--- a/app/rust/src/api/achievement.rs
+++ b/app/rust/src/api/achievement.rs
@@ -19,7 +19,9 @@ fn cached_explored_areas(layers: &[AchievementLayer]) -> Result<HashMap<Achievem
             Some(AchievementValue::U64(area)) => {
                 out.insert(layer, area);
             }
-            _ => {
+            // When we added some types, we should panic when there is a type
+            // mismatch because that means there is a BUG.
+            None => {
                 let computed = compute_explored_areas(&state.storage, layers)?;
                 for (&layer, &area) in &computed {
                     cache.put(

--- a/app/rust/src/api/api.rs
+++ b/app/rust/src/api/api.rs
@@ -11,6 +11,7 @@ use csv::Reader;
 use flutter_rust_bridge::frb;
 
 use super::import::JourneyInfo;
+use crate::achievement::stat_cache::StatCache;
 use crate::cache_db::LayerKind;
 use crate::frb_generated::StreamSink;
 use crate::gps_processor::{GpsPreprocessor, ProcessResult};
@@ -37,6 +38,7 @@ use log::{error, info, warn};
 pub(super) struct MainState {
     pub storage: Storage,
     pub gps_preprocessor: Mutex<GpsPreprocessor>,
+    pub stat_cache: StatCache,
     main_map_state: Arc<Mutex<MainMapState>>,
 }
 
@@ -118,12 +120,15 @@ pub fn init(temp_dir: String, doc_dir: String, support_dir: String, system_cache
                     error!("Failed to get latest bitmap for main map renderer: {e:?}");
                 }
             }
+            // Journey set changed — evict cached stats.
+            get().stat_cache.invalidate();
         }));
         info!("main map renderer initialized");
 
         MainState {
             storage,
             gps_preprocessor: Mutex::new(GpsPreprocessor::new()),
+            stat_cache: StatCache::default(),
             main_map_state,
         }
     });

--- a/app/rust/tests/achievement_area.rs
+++ b/app/rust/tests/achievement_area.rs
@@ -1,0 +1,101 @@
+pub mod test_utils;
+use crate::test_utils::{draw_line1, draw_line2};
+use chrono::NaiveDate;
+use memolanes_core::{
+    achievement::explored_area::compute_explored_areas, achievement::scope::AchievementLayer,
+    journey_area_utils::compute_journey_bitmap_area, journey_bitmap::JourneyBitmap,
+    journey_data::JourneyData, journey_header::JourneyKind, storage::Storage,
+};
+use std::fs;
+use tempdir::TempDir;
+
+fn setup_storage_for_test<F>(f: F)
+where
+    F: FnOnce(Storage),
+{
+    let temp_dir = TempDir::new("test_achievement_area").unwrap();
+    let sub_folder = |sub| {
+        let path = temp_dir.path().join(sub);
+        fs::create_dir(&path).unwrap();
+        path.into_os_string().into_string().unwrap()
+    };
+    let storage = Storage::init(
+        sub_folder("temp/"),
+        sub_folder("doc/"),
+        sub_folder("support/"),
+        sub_folder("cache/"),
+    );
+    f(storage);
+}
+
+/// Direct computation of a layer's explored area — the oracle
+/// `compute_explored_areas` must reproduce.
+fn oracle_area(storage: &Storage, layer: AchievementLayer) -> u64 {
+    storage
+        .with_journey_snapshot(|snapshot| {
+            let bitmap = snapshot.finalized_bitmap(&layer.to_layer_kind(), None)?;
+            Ok(compute_journey_bitmap_area(&bitmap, None))
+        })
+        .unwrap()
+}
+
+#[test]
+fn compute_explored_areas_matches_direct_fold() {
+    setup_storage_for_test(|storage| {
+        let layers = AchievementLayer::ALL_LAYERS;
+
+        // Empty storage: every layer maps to zero.
+        let empty = compute_explored_areas(&storage, &layers).unwrap();
+        assert_eq!(empty.len(), 3);
+        assert_eq!(empty[&AchievementLayer::Default], 0);
+        assert_eq!(empty[&AchievementLayer::Flight], 0);
+        assert_eq!(empty[&AchievementLayer::All], 0);
+
+        // A Default journey and a Flight journey covering different lines.
+        let mut default_bitmap = JourneyBitmap::new();
+        draw_line1(&mut default_bitmap);
+        let mut flight_bitmap = JourneyBitmap::new();
+        draw_line2(&mut flight_bitmap);
+
+        storage
+            .with_db_txn(|txn| {
+                txn.create_and_insert_journey(
+                    NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+                    None,
+                    None,
+                    None,
+                    JourneyKind::DefaultKind,
+                    None,
+                    JourneyData::Bitmap(default_bitmap.clone()),
+                )
+            })
+            .unwrap();
+        storage
+            .with_db_txn(|txn| {
+                txn.create_and_insert_journey(
+                    NaiveDate::from_ymd_opt(2025, 1, 2).unwrap(),
+                    None,
+                    None,
+                    None,
+                    JourneyKind::Flight,
+                    None,
+                    JourneyData::Bitmap(flight_bitmap.clone()),
+                )
+            })
+            .unwrap();
+
+        // Map result equals the direct fold for every layer.
+        let map = compute_explored_areas(&storage, &layers).unwrap();
+        for layer in layers {
+            assert_eq!(map[&layer], oracle_area(&storage, layer), "layer {layer:?}");
+        }
+
+        // Non-empty; `All` is a superset of each component layer.
+        let default = map[&AchievementLayer::Default];
+        let flight = map[&AchievementLayer::Flight];
+        let all = map[&AchievementLayer::All];
+        assert!(default > 0);
+        assert!(flight > 0);
+        assert!(all >= default && all >= flight);
+    });
+}

--- a/app/rust/tests/achievement_stat_cache.rs
+++ b/app/rust/tests/achievement_stat_cache.rs
@@ -1,0 +1,31 @@
+use memolanes_core::achievement::query::{AchievementQuery, AchievementValue};
+use memolanes_core::achievement::scope::AchievementLayer;
+use memolanes_core::achievement::stat_cache::StatCache;
+
+fn v(n: u64) -> AchievementValue {
+    AchievementValue::U64(n)
+}
+
+fn q(layer: AchievementLayer) -> AchievementQuery {
+    AchievementQuery::ExploredAreaM2 { layer }
+}
+
+#[test]
+fn round_trips_and_isolates_keys() {
+    let c = StatCache::default();
+    c.put(q(AchievementLayer::Default), v(1));
+    c.put(q(AchievementLayer::Flight), v(2));
+    assert_eq!(c.get(&q(AchievementLayer::Default)), Some(v(1)));
+    assert_eq!(c.get(&q(AchievementLayer::Flight)), Some(v(2)));
+    assert_eq!(c.get(&q(AchievementLayer::All)), None);
+}
+
+#[test]
+fn invalidate_evicts_all() {
+    let c = StatCache::default();
+    c.put(q(AchievementLayer::Default), v(1));
+    c.put(q(AchievementLayer::Flight), v(2));
+    c.invalidate();
+    assert_eq!(c.get(&q(AchievementLayer::Default)), None);
+    assert_eq!(c.get(&q(AchievementLayer::Flight)), None);
+}


### PR DESCRIPTION
Adds the explored-area achievement read-model.

Computes total explored area (m²) per layer from each layer's merged bitmap, read under one consistent journey snapshot, and exposes it via `get_explored_area` and `get_explored_area_by_layer` (per-layer map).

Reads go through a general `StatCache` keyed by a query memo key (`AchievementQuery`/`AchievementValue`), so later stats extend the query and value enums rather than the cache itself. Results are memoized in an `InMemoryStatCache`, evicted event-driven by the post-commit finalized-journey callback (no version counter); on any miss the whole requested set is recomputed under one snapshot so the layers cannot mix journey states.

Covered by integration tests in `tests/achievement_area.rs` and `tests/achievement_stat_cache.rs`.
