### PR TITLE
region_level_view: parent None lists whole level

### DIFF
--- a/app/rust/src/achievement/read_model/region.rs
+++ b/app/rust/src/achievement/read_model/region.rs
@@ -81,11 +81,15 @@ fn entities_in_scope(
     level: GeoEntityKind,
     parent: Option<GeoEntityId>,
 ) -> Vec<GeoEntityId> {
-    geo.entities_of_kind(level)
-        .iter()
-        .copied()
-        .filter(|&id| geo.entity(id).map(|e| e.parent_id) == Some(parent))
-        .collect()
+    let ids = geo.entities_of_kind(level);
+    match parent {
+        None => ids.to_vec(),
+        Some(parent) => ids
+            .iter()
+            .copied()
+            .filter(|&id| geo.entity(id).map(|e| e.parent_id) == Some(Some(parent)))
+            .collect(),
+    }
 }
 
 /// One entity's coverage in `layer`, or `None` if the id is unknown.

--- a/app/rust/src/archive.rs
+++ b/app/rust/src/archive.rs
@@ -56,8 +56,8 @@ use crate::{
     protos::archive::{metadata, Metadata, SectionHeader},
 };
 
-const METADATA_MAGIC_HEADER: [u8; 3] = [b'M', b'L', b'M'];
-const SECTION_MAGIC_HEADER: [u8; 3] = [b'M', b'L', b'S'];
+const METADATA_MAGIC_HEADER: [u8; 3] = *b"MLM";
+const SECTION_MAGIC_HEADER: [u8; 3] = *b"MLS";
 const METADATA_VERSION: u8 = 1;
 const METADATA_FILE_NAME_OLD: &str = "metadata.xxm";
 const METADATA_FILE_NAME_NEW: &str = "metadata.mldm";
@@ -188,7 +188,7 @@ impl<R: Read + Seek> MldxReader<R> {
             bail!(
                 "Invalid magic header, expect: {:?}, got: {:?}",
                 METADATA_MAGIC_HEADER,
-                &magic_header
+                magic_header
             );
         };
         let mut version_number: [u8; 1] = [0; 1];
@@ -215,7 +215,7 @@ impl<R: Read + Seek> MldxReader<R> {
             bail!(
                 "Invalid magic header, expect: {:?}, got: {:?}",
                 SECTION_MAGIC_HEADER,
-                &magic_header
+                magic_header
             );
         };
         let mut version_number: [u8; 1] = [0; 1];
@@ -446,7 +446,7 @@ where
             .or_insert_with(Vec::new)
             .push(journey);
     }
-    for (_, journeys) in group_by_year_month.iter_mut() {
+    for journeys in group_by_year_month.values_mut() {
         journeys.sort_by(|a, b| {
             let result = a.end.cmp(&b.end);
             if result != Ordering::Equal {

--- a/app/rust/src/journey_data.rs
+++ b/app/rust/src/journey_data.rs
@@ -21,8 +21,8 @@ pub enum JourneyData {
 // 3 is the zstd default
 pub const ZSTD_COMPRESS_LEVEL: i32 = 3;
 
-const JOURNEY_VECTOR_MAGIC_HEADER: [u8; 2] = [b'V', b'0'];
-const JOURNEY_BITMAP_MAGIC_HEADER: [u8; 2] = [b'B', b'0'];
+const JOURNEY_VECTOR_MAGIC_HEADER: [u8; 2] = *b"V0";
+const JOURNEY_BITMAP_MAGIC_HEADER: [u8; 2] = *b"B0";
 
 pub fn validate_magic_header<T: Read>(reader: &mut T, expected_header: &[u8; 2]) -> Result<()> {
     // magic header
@@ -32,7 +32,7 @@ pub fn validate_magic_header<T: Read>(reader: &mut T, expected_header: &[u8; 2])
         bail!(
             "Invalid magic header, expect: {:?}, got: {:?}",
             expected_header,
-            &magic_header
+            magic_header
         );
     };
     Ok(())

--- a/app/rust/src/main_db.rs
+++ b/app/rust/src/main_db.rs
@@ -211,13 +211,13 @@ impl Txn<'_> {
                 if existing_header.revision == header.revision {
                     info!(
                         "Journey with ID {} already exists with the same revision, skip insert",
-                        &header.id
+                        header.id
                     );
                     return Ok(());
                 } else {
                     bail!(
                         "Journey with ID {} already exists but with a different revision",
-                        &header.id
+                        header.id
                     );
                 }
             }
@@ -319,7 +319,7 @@ impl Txn<'_> {
         note: Option<String>,
         new_journey_kind: JourneyKind,
     ) -> Result<()> {
-        info!("Updating journey with ID {}", &id);
+        info!("Updating journey with ID {}", id);
 
         let mut header = self
             .get_journey_header(id)?
@@ -369,7 +369,7 @@ impl Txn<'_> {
         id: &str,
         journey_data: JourneyData,
     ) -> Result<()> {
-        info!("Updating journey data with ID {}", &id);
+        info!("Updating journey data with ID {}", id);
 
         let mut header = self
             .get_journey_header(id)?

--- a/app/rust/tests/region_api.rs
+++ b/app/rust/tests/region_api.rs
@@ -135,6 +135,12 @@ fn region_read_api_lists_progress_and_completion() {
             let all = region_level_view(&states, geo, All, RegionKind::Country, eu);
             assert_eq!((all.visited_count, all.region_count), (2, 2));
 
+            let world = region_level_view(&states, geo, All, RegionKind::Country, None);
+            let mut world_ids: Vec<_> = world.entries.keys().copied().collect();
+            world_ids.sort();
+            assert_eq!(world_ids, vec![GeoEntityId(2), GeoEntityId(3)]);
+            assert_eq!((world.visited_count, world.region_count), (2, 2));
+
             // Detail of EU (All layer): single-layer node + FR/DE children.
             let detail = region_detail(&states, geo, GeoEntityId(1), All).unwrap();
             assert_eq!(detail.entity_id, GeoEntityId(1));


### PR DESCRIPTION
`parent: None` filtered to parentless roots, so the country level came back empty (every country parents a continent). Treat `None` as no parent filter → lists all entities of the level (all countries; visited ones carry area).

API signature unchanged. Test added for `None` at country level.