### PR TITLE
Some small bug fixes

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,12 @@
             <meta-data
                 android:name="io.flutter.embedding.android.NormalTheme"
                 android:resource="@style/NormalTheme" />
+            <!-- Share intents are handled by share_handler. Some sending apps put
+                 the shared content URI in Intent.data, which Flutter would
+                 otherwise interpret as a named route. -->
+            <meta-data
+                android:name="flutter_deeplinking_enabled"
+                android:value="false" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/lib/common/component/base_map_webview.dart
+++ b/app/lib/common/component/base_map_webview.dart
@@ -163,6 +163,14 @@ class BaseMapWebviewState extends State<BaseMapWebview> {
       } catch (e) {
         log.error('[base_map_webview] Failed to query battery save mode: $e');
       }
+    }, onError: (Object error) {
+      // Charging status is only used as a signal to refresh low-power mode.
+      // Some devices cannot provide it temporarily, so keep the stream alive
+      // and retain the last known low-power-mode value.
+      log.warning(
+        '[base_map_webview] Battery state unavailable; '
+        'keeping the last known low-power mode: $error',
+      );
     });
   }
 

--- a/app/test/android_manifest_test.dart
+++ b/app/test/android_manifest_test.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Flutter deep-link routing is disabled for Android share intents', () {
+    final manifest =
+        File('android/app/src/main/AndroidManifest.xml').readAsStringSync();
+
+    expect(
+      manifest,
+      contains(
+        RegExp(
+          r'android:name="flutter_deeplinking_enabled"\s*'
+          r'android:value="false"',
+        ),
+      ),
+      reason: 'MemoLanes handles incoming share intents with share_handler. '
+          'Flutter must not also interpret a shared Intent.data URI as a route.',
+    );
+  });
+}


### PR DESCRIPTION
These fixes are for:
```
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: PlatformException(UNAVAILABLE, Charging status unavailable, null, null)
       at FirebaseCrashlytics.recordError(firebase_crashlytics.dart:119)
       at main.<fn>(main.dart:67)```
```

And 
```
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: Null check operator used on a null value. Error thrown .
       at _WidgetsAppState._onUnknownRoute(app.dart:1590)
       at NavigatorState._routeNamed(navigator.dart:4700)
       at NavigatorState.pushNamed(navigator.dart:4747)
       at _WidgetsAppState.didPushRouteInformation(app.dart:1636)
       at WidgetsBinding._handlePushRouteInformation(binding.dart:1286)
       at MethodChannel._handleAsMethodCall(platform_channel.dart:607)
       at _DefaultBinaryMessenger.setMessageHandler.<fn>(binding.dart:663)
```