### PR TITLE
geo: source region names from CLDR instead of Natural Earth

### DIFF
--- a/app/rust/geo_data_format/src/cldr.rs
+++ b/app/rust/geo_data_format/src/cldr.rs
@@ -1,0 +1,45 @@
+//! NE `ISO_A2_EH` to CLDR `ISO_3166-1_alpha-2`
+
+use crate::Locale;
+
+pub const CLDR_TAG: &str = "48.2.0";
+
+pub const CLDR_BASE: &str = "https://raw.githubusercontent.com/unicode-org/cldr-json/\
+     48.2.0/cldr-json/cldr-localenames-full/main";
+
+impl Locale {
+    pub fn cldr_source_url(self) -> String {
+        format!("{CLDR_BASE}/{}/territories.json", self.spec().cldr_tag)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cldr_table_is_consistent() {
+        for &locale in Locale::ALL {
+            let url = locale.cldr_source_url();
+            assert!(
+                url.starts_with(CLDR_BASE),
+                "url not under pinned base: {url}"
+            );
+            assert!(url.ends_with("/territories.json"));
+            let sha = locale.spec().cldr_source_sha256;
+            assert_eq!(sha.len(), 64, "sha must be 64 hex chars");
+            assert!(sha.bytes().all(|b| b.is_ascii_hexdigit()));
+        }
+        assert!(
+            CLDR_BASE.starts_with("https://raw.githubusercontent.com/unicode-org/cldr-json/"),
+            "base URL looks wrong: {CLDR_BASE}"
+        );
+        assert!(!CLDR_BASE.contains(' '), "base has embedded whitespace");
+        // Pin desync guard: the base must embed the pinned tag, so a future
+        // bump that updates only one of the two consts fails here.
+        assert!(
+            CLDR_BASE.contains(CLDR_TAG),
+            "CLDR_BASE does not contain CLDR_TAG (pin desync)"
+        );
+    }
+}

--- a/app/rust/geo_data_format/src/lib.rs
+++ b/app/rust/geo_data_format/src/lib.rs
@@ -56,12 +56,14 @@ pub fn cell_index(x: u8, y: u8) -> usize {
     x as usize * TILE_WIDTH + y as usize
 }
 
+mod cldr;
 mod format;
 mod locale;
 mod packed_tile;
 mod types;
 mod worldview;
 
+pub use cldr::*;
 pub use format::{
     expected_total_len, read_geo_data, write_geo_data, GeoData, TileEntry, HEADER_LEN,
 };

--- a/app/rust/geo_data_format/src/locale.rs
+++ b/app/rust/geo_data_format/src/locale.rs
@@ -8,8 +8,8 @@ pub struct LocaleSpec {
     /// BCP-47 tag. Must match a `LocaleConstants.supportedLocales` entry in
     /// `app/lib/constants/locale_constants.dart`
     pub tag: &'static str,
-    /// Natural Earth property holding this locale's name (e.g. `NAME_ZH`).
-    pub ne_field: &'static str,
+    pub cldr_tag: &'static str,
+    pub cldr_source_sha256: &'static str,
 }
 
 impl Locale {
@@ -19,11 +19,15 @@ impl Locale {
         match self {
             Locale::EnUs => LocaleSpec {
                 tag: "en-US",
-                ne_field: "NAME_EN",
+                cldr_tag: "en",
+                cldr_source_sha256:
+                    "158c1d575308f7e46912edbeda435c8fe2ef5dad280798231f3a432e406b1807",
             },
             Locale::ZhCn => LocaleSpec {
                 tag: "zh-CN",
-                ne_field: "NAME_ZH",
+                cldr_tag: "zh",
+                cldr_source_sha256:
+                    "18f1426f1e8981a671517a4857a8d4e56060909906c4cfd9b9a43a8a18b9ab6f",
             },
         }
     }

--- a/app/test/app_translation_loader_test.dart
+++ b/app/test/app_translation_loader_test.dart
@@ -40,7 +40,7 @@ void main() {
     // Nested levels, same shape as the UI files — easy_localization resolves
     // a dotted `name_key` by walking them.
     final country = map['country'] as Map<String, dynamic>;
-    expect(country['CHN'], "People's Republic of China");
+    expect(country['CHN'], 'China');
     final continent = map['continent'] as Map<String, dynamic>;
     expect(continent['AS'], 'Asia');
     // UI translations survive the merge (disjoint top-level namespace).
@@ -77,7 +77,7 @@ void main() {
     // 1. localized name from the catalog.
     expect(
       _entity(nameKey: 'country.CHN', isoA3Eh: 'CHN').displayName('iso'),
-      "People's Republic of China",
+      'China',
     );
     // 2. a key the catalog lacks → ISO code.
     expect(

--- a/tools/geo_rasterizer/.gitignore
+++ b/tools/geo_rasterizer/.gitignore
@@ -9,3 +9,8 @@ tests/fixtures/*.bin.tmp
 # `*.tmp` covers the in-flight download before it's renamed into place.
 natural_earth/ne_10m_admin_0_countries_*.geojson
 natural_earth/*.tmp
+
+# CLDR territory-name source downloaded on demand by `just rasterize-geo`,
+# reproducible from the pin in geo_data_format::cldr.
+cldr/territories.*.json
+cldr/*.tmp

--- a/tools/geo_rasterizer/README.md
+++ b/tools/geo_rasterizer/README.md
@@ -4,7 +4,8 @@ Offline build tool. Converts Natural Earth GeoJSON into the geo-reference data
 shipped in `app/assets/geo/`:
 
 - `geo_data_<worldview>.bin` — the packed entity/tile data (one per worldview).
-- `region_names.<locale>.json` — the localized region-name maps (one per locale).
+- `region_names.<locale>.json` — the localized region-name maps (one per
+  locale), resolved from Unicode CLDR (see "Region names" below).
 
 Run via the `app/` Justfile (`just rasterize-geo`); it is not part of the app at
 runtime. Both outputs are git-ignored and reproducible from the pinned source.
@@ -153,40 +154,57 @@ Resolution per name, in order:
 
 1. worldview-scoped override → a `<worldview>.<name_key>` key (see below),
 2. worldview-agnostic override,
-3. the locale's Natural Earth `NAME_*` field on the group's sovereign member,
+3. the CLDR territory name for the group's sovereign member's `ISO_A2_EH`,
 4. hard error — never a silent English fallback.
 
-**One map per locale, not per worldview.** Natural Earth's POV files normally
-agree on names (they differ on *borders*, not names), so the map is keyed by
-`name_key` alone, unioned across worldviews; the `.bin`'s per-worldview entity
-set decides which keys a worldview actually uses. If a future Natural Earth bump
-makes a code's names diverge across worldviews, generation fails loudly — unless
-the divergence is covered by overrides: a worldview-agnostic override replaces
-the Natural Earth names outright, or scoped overrides peel the divergent
-worldviews off onto `<worldview>.<name_key>` keys, in which case every worldview
-still reading the shared key must agree on its value.
+**Names come from CLDR, not Natural Earth.** Unicode CLDR
+(`cldr-localenames-full`, pinned in `geo_data_format::cldr`) is the canonical,
+per-locale authority for territory names, keyed by ISO 3166-1 alpha-2. Natural
+Earth supplies only the geometry and the `ISO_A2_EH` code that joins a feature to
+its CLDR name. A CLDR name depends on the alpha-2 alone, so a country resolves to
+the same name across every worldview by construction — the map is keyed by
+`name_key`, unioned across worldviews, and a given `ADM0_A3` must carry the same
+`ISO_A2_EH` in every worldview (generation fails otherwise).
 
-`geo_names_overrides.toml` is the only hand-authored part. Two reasons an override
-exists: Natural Earth has no name (continents have no feature of their own, so
-**every** continent name is authored here; a collapsed group with no sovereign
-member has none), or its name is not one we ship. A key is a locale string; a
-per-worldview override is a sub-table:
+**Collision gate.** Natural Earth stamps some sub-features (disputed regions,
+sovereign bases, outlying islands) with their *sovereign's* `ISO_A2_EH`, so CLDR
+would name each after its sovereign — two distinct regions both reading
+"Georgia". Generation requires at most one CLDR-resolved entity per alpha-2; the
+sub-features must carry an override, or the build fails listing the collision.
+The coverage gate can't catch this (the name is non-empty), so this gate does.
+
+`geo_names_overrides.toml` is the only hand-authored part. An override exists
+where CLDR cannot give the name we ship:
+
+- **No CLDR territory / no alpha-2.** Continents are synthesized (no feature, so
+  **every** continent name is authored here); NE-only aggregates (the Spratlys)
+  and `-99`-sentinel entities (Bir Tawil, the Cyprus base areas) have no CLDR
+  entry.
+- **Sub-feature sharing a sovereign's alpha-2** (see the collision gate) —
+  Abkhazia, South Ossetia, Clipperton Island, ….
+- **CLDR's name is not the form we ship** — e.g. CLDR's verbose "Hong Kong SAR
+  China" shortened to "Hong Kong".
+
+A key is a locale string; a per-worldview override is a sub-table:
 
 ```toml
-["country.TWN"]        # default: every worldview
-zh-CN = "台湾"
+["country.HKG"]        # default: every worldview
+en-US = "Hong Kong"
 
-["country.TWN".chn]    # chn worldview only; emitted as `chn.country.TWN`
+["country.AAA".chn]    # chn worldview only; emitted as `chn.country.AAA`
 zh-CN = "…"
 ```
 
 ### Regenerating after an overrides edit
 
 `just rasterize-geo` — the names pass always reruns and picks up the edit (the
-`.bin`s hash `geojson + registry`, not the overrides, so they skip). Then
-`just test-geo` runs the coverage gate (`tests/names_coverage.rs`): every entity
-in every worldview must resolve to a non-empty name in every locale. Commit only
-the `.toml` — the JSON are git-ignored build artifacts.
+`.bin`s hash `geojson + registry`, not the overrides, so they skip; CLDR sources
+are downloaded on demand and verified against the pin, same as the geojson).
+Generation reports every unresolved gap and every alpha-2 collision in one run,
+so overrides can be authored in one pass. Then `just test-geo` runs the coverage
+gate (`tests/names_coverage.rs`): every entity in every worldview must resolve to
+a non-empty name in every locale. Commit only the `.toml` — the JSON are
+git-ignored build artifacts.
 
 ## Future work
 

--- a/tools/geo_rasterizer/geo_names_overrides.toml
+++ b/tools/geo_rasterizer/geo_names_overrides.toml
@@ -45,32 +45,96 @@ en-US = "South America"
 zh-CN = "南美洲"
 
 # --- Countries --------------------------------------------------------------
+# CLDR names territories keyed by ISO 3166-1 alpha-2. The entities below have no
+# alpha-2 (their `ISO_A2_EH` is the `-99` sentinel) or no CLDR territory of their
+# own, so CLDR cannot name them and the name is authored here. Values are carried
+# over from Natural Earth's `NAME_EN` / `NAME_ZH`. Sorted by code.
 
-# In the iso worldview, IOA is a collapsed group (Christmas I. + Cocos Is.) with
-# no `TYPE == "Country"` member, so there is no sovereign feature to take a name
-# from — Natural Earth carries no name for it in ANY language. The chn/usa
-# worldviews do have a single IOA feature, but its NAME_ZH is Traditional
-# Chinese (澳屬印度洋領地), so zh-CN is authored here for every worldview.
+# --- Sub-features sharing a sovereign's ISO_A2_EH -----------------------------
+# Natural Earth stamps these with their *sovereign's* alpha-2, so CLDR would name
+# each after the sovereign (Georgia, Australia, …). Distinct names are authored
+# here; the build's collision gate fails if a new such entity appears unhandled.
+
+# Georgian breakaway regions; NE ISO_A2_EH = GE (Georgia).
+["country.B35"]
+en-US = "Abkhazia"
+zh-CN = "阿布哈兹"
+
+["country.B37"]
+en-US = "South Ossetia"
+zh-CN = "南奥塞梯"
+
+# Australian external features; NE ISO_A2_EH = AU (Australia).
+["country.ATC"]
+en-US = "Ashmore and Cartier Islands"
+zh-CN = "阿什莫尔和卡捷群岛"
+
+["country.CSI"]
+en-US = "Coral Sea Islands"
+zh-CN = "珊瑚海群岛"
+
+# NE ISO_A2_EH = BR (Brazil).
+["country.BRI"]
+en-US = "Brazilian Island"
+zh-CN = "巴西岛"
+
+# NE ISO_A2_EH = FR (France).
+["country.CLP"]
+en-US = "Clipperton Island"
+zh-CN = "克利珀顿岛"
+
+# --- Shortened from CLDR's verbose primary form -------------------------------
+# CLDR's primary territory name is the long SAR form ("Hong Kong SAR China" /
+# 中国香港特别行政区); the short form (CLDR's own `-alt-short`) reads better as a
+# map label.
+["country.HKG"]
+en-US = "Hong Kong"
+zh-CN = "香港"
+
+["country.MAC"]
+en-US = "Macao"
+zh-CN = "澳门"
+
+# CLDR primary is "Palestinian Territories" / 巴勒斯坦领土; short form preferred.
+["country.PSX"]
+en-US = "Palestine"
+zh-CN = "巴勒斯坦"
+
+# --- No ISO alpha-2 / no CLDR territory ---------------------------------------
+
+# Terra nullius between Egypt and Sudan; no ISO alpha-2, no CLDR territory.
+["country.BRT"]
+en-US = "Bir Tawil"
+zh-CN = "比尔泰维勒"
+
+# UK Sovereign Base Area (Dhekelia, Eastern) on Cyprus; no ISO alpha-2.
+["country.ESB"]
+en-US = "Dhekelia Cantonment"
+zh-CN = "泽凯利亚军营"
+
+# Aggregate of Christmas I. + Cocos Is.; no ISO alpha-2, no CLDR territory. (In
+# the iso worldview it is also a collapsed group with no sovereign member.)
 ["country.IOA"]
 en-US = "Australian Indian Ocean Territories"
 zh-CN = "澳属印度洋领地"
 
-# Natural Earth's NAME_ZH for TWN is 中华民国.
-["country.TWN"]
-zh-CN = "台湾"
-
-# Natural Earth's localized columns for PGA name the WRONG PLACE: NAME_EN is
-# "Wake Island" and NAME_ZH is 威克岛, but the feature's geometry is the Spratly
-# archipelago (lon 114.03..115.85, lat 9.68..11.12) — ~5,700 km from Wake, which
-# NE carries separately and correctly under UMI. NE's own NAME ("Spratly Is.")
-# and SOVEREIGNT ("Spratly Islands") columns agree with the geometry, so it is
-# the localized columns that are wrong, not our reading of them.
-#
-# The coverage gate cannot catch this class of defect: it proves every entity HAS
-# a non-empty name, not that the name is the right one. A token-overlap audit of
-# NAME_EN against NAME/SOVEREIGNT across all three worldviews found PGA to be the
-# only genuine mislabel (the other divergences are spelling variants: Czechia /
-# Czech Republic, Faeroe / Faroe, Macao / Macau, S. Geo. and the Is.).
+# NE-only aggregate: the feature geometry is the Spratly archipelago, which CLDR
+# has no territory for.
 ["country.PGA"]
 en-US = "Spratly Islands"
 zh-CN = "南沙群岛"
+
+# Disputed shoal; no ISO alpha-2, no CLDR territory.
+["country.SCR"]
+en-US = "Scarborough Shoal"
+zh-CN = "黄岩岛"
+
+# US naval base leased from Cuba; no ISO alpha-2, no CLDR territory.
+["country.USG"]
+en-US = "Guantanamo Bay Naval Base"
+zh-CN = "关塔那摩湾海军基地"
+
+# UK Sovereign Base Area (Akrotiri, Western) on Cyprus; no ISO alpha-2.
+["country.WSB"]
+en-US = "Akrotiri Sovereign Base Area"
+zh-CN = "阿克罗蒂里主权基地区"

--- a/tools/geo_rasterizer/src/cldr.rs
+++ b/tools/geo_rasterizer/src/cldr.rs
@@ -1,0 +1,53 @@
+//! Load a pinned CLDR `territories.json` into an alpha-2 → display-name map.
+//!
+//! Shape (see `geo_data_format::cldr` for the pin):
+//! ```json
+//! { "main": { "en": { "localeDisplayNames": { "territories": {
+//!     "US": "United States", "US-alt-short": "US", "US-alt-…": "…" } } } } }
+//! ```
+//! Keys are ISO 3166-1 alpha-2 (plus numeric M49 region codes, which never match
+//! an `ISO_A2_EH` lookup and so pass through harmlessly). We take the **primary**
+//! form only — `<code>-alt-*` variants (short/variant/…) are skipped.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::{anyhow, bail, Context, Result};
+
+pub fn load_territories(path: &Path, cldr_tag: &str) -> Result<BTreeMap<String, String>> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("reading CLDR territories at {}", path.display()))?;
+    let root: serde_json::Value = serde_json::from_str(&raw)
+        .with_context(|| format!("parsing CLDR territories at {}", path.display()))?;
+
+    let territories = root
+        .get("main")
+        .and_then(|m| m.get(cldr_tag))
+        .and_then(|l| l.get("localeDisplayNames"))
+        .and_then(|d| d.get("territories"))
+        .and_then(|t| t.as_object())
+        .ok_or_else(|| {
+            anyhow!(
+                "{}: missing main.{cldr_tag}.localeDisplayNames.territories",
+                path.display()
+            )
+        })?;
+
+    let mut out = BTreeMap::new();
+    for (code, name) in territories {
+        if code.contains("-alt-") {
+            continue;
+        }
+        let name = name
+            .as_str()
+            .ok_or_else(|| anyhow!("{}: territory `{code}` is not a string", path.display()))?;
+        out.insert(code.clone(), name.to_string());
+    }
+    if out.is_empty() {
+        bail!(
+            "{}: main.{cldr_tag}.localeDisplayNames.territories has no primary entries",
+            path.display()
+        );
+    }
+    Ok(out)
+}

--- a/tools/geo_rasterizer/src/download.rs
+++ b/tools/geo_rasterizer/src/download.rs
@@ -1,28 +1,39 @@
-//! Natural Earth source download helper.
-//!
-//! The pinned commit/URL/hash live in `geo_data_format::worldview` (deliberate change,
-//! single PR) rather than as CLI arguments; this module just fetches + verifies.
-
 use std::fs;
 use std::io::Read;
 use std::path::Path;
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};
-use geo_data_format::Worldview;
+use geo_data_format::{Locale, Worldview};
 use indicatif::{ProgressBar, ProgressStyle};
 use sha2::{Digest, Sha256};
 
 use crate::atomic_write::write_atomically_with;
 
-/// Ensure `path` contains the pinned Natural Earth GeoJSON. If the file is
-/// missing or its SHA-256 doesn't match the pin, re-download and verify.
 pub fn ensure_geojson(path: &Path, worldview: Worldview) -> Result<()> {
-    let url = worldview.source_url();
-    let expected = worldview.spec().source_sha256;
+    ensure_pinned(
+        path,
+        &worldview.source_url(),
+        worldview.spec().source_sha256,
+    )
+}
+
+pub fn ensure_cldr(path: &Path, locale: Locale) -> Result<()> {
+    ensure_pinned(
+        path,
+        &locale.cldr_source_url(),
+        locale.spec().cldr_source_sha256,
+    )
+}
+
+fn ensure_pinned(path: &Path, url: &str, expected: &str) -> Result<()> {
     match sha256_of(path)? {
         Some(actual) if actual == expected => {
-            eprintln!("[geo_rasterizer] geojson cache hit ({})", &expected[..12]);
+            eprintln!(
+                "[geo_rasterizer] {} cache hit ({})",
+                path.display(),
+                &expected[..12]
+            );
             return Ok(());
         }
         Some(actual) => eprintln!(
@@ -43,7 +54,7 @@ pub fn ensure_geojson(path: &Path, worldview: Worldview) -> Result<()> {
             fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
         }
     }
-    download_to(path, &url).with_context(|| format!("downloading {}", path.display()))?;
+    download_to(path, url).with_context(|| format!("downloading {}", path.display()))?;
 
     let actual =
         sha256_of(path)?.ok_or_else(|| anyhow!("downloaded file vanished: {}", path.display()))?;

--- a/tools/geo_rasterizer/src/lib.rs
+++ b/tools/geo_rasterizer/src/lib.rs
@@ -2,6 +2,7 @@ mod absorb;
 pub mod area;
 pub mod atomic_write;
 pub mod cache;
+pub mod cldr;
 pub mod download;
 pub mod entities;
 pub mod names;

--- a/tools/geo_rasterizer/src/main.rs
+++ b/tools/geo_rasterizer/src/main.rs
@@ -1,14 +1,16 @@
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::time::Instant;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use geo_data_format::{write_geo_data, Worldview};
+use geo_data_format::{write_geo_data, Locale, Worldview};
 use geo_rasterizer::{
     area::populate_total_areas,
     atomic_write::write_atomically,
     cache::{compute_provenance_hash, read_existing_hash},
-    download::ensure_geojson,
+    cldr::load_territories,
+    download::{ensure_cldr, ensure_geojson},
     entities::assemble_entities,
     names::{build_region_names, write_region_names},
     overrides::Overrides,
@@ -79,6 +81,12 @@ fn default_overrides() -> PathBuf {
     manifest().join("geo_names_overrides.toml")
 }
 
+fn default_cldr(locale: Locale) -> PathBuf {
+    manifest()
+        .join("cldr")
+        .join(format!("territories.{}.json", locale.spec().cldr_tag))
+}
+
 fn generate_region_names(ensure_source: bool) -> Result<()> {
     let overrides = Overrides::load(&default_overrides())?;
     let mut by_worldview = Vec::new();
@@ -89,7 +97,15 @@ fn generate_region_names(ensure_source: bool) -> Result<()> {
         }
         by_worldview.push((worldview, parse_geojson(&path, worldview.spec().id)?));
     }
-    let names = build_region_names(&by_worldview, &overrides)?;
+    let mut cldr = BTreeMap::new();
+    for &locale in Locale::ALL {
+        let path = default_cldr(locale);
+        if ensure_source {
+            ensure_cldr(&path, locale)?;
+        }
+        cldr.insert(locale, load_territories(&path, locale.spec().cldr_tag)?);
+    }
+    let names = build_region_names(&by_worldview, &cldr, &overrides)?;
     for (locale, map) in &names {
         let path = write_region_names(&geo_assets_dir(), *locale, map)?;
         eprintln!(

--- a/tools/geo_rasterizer/src/names.rs
+++ b/tools/geo_rasterizer/src/names.rs
@@ -4,20 +4,24 @@
 //! the same shape as the UI translation files, and the shape easy_localization
 //! resolves natively.
 //!
-//! The un-prefixed key is worldview-agnostic. Worldviews normally agree on
-//! names (Natural Earth's POV files differ in *borders*, not names); when a
-//! future source bump makes them diverge, a worldview-scoped override supplies
-//! the divergent worldview's name under a `<worldview>.<name_key>` key the app
-//! prefers, and every worldview still reading the shared key must agree on its
-//! value — generation fails otherwise.
+//! Names come from Unicode CLDR (`territories.json`, keyed by ISO 3166-1
+//! alpha-2), joined to each entity via the sovereign feature's `ISO_A2_EH`.
+//! CLDR names are worldview-independent, so a country resolves to one name
+//! across every worldview by construction — the un-prefixed key is
+//! worldview-agnostic. (A given `ADM0_A3` must therefore carry the same
+//! `ISO_A2_EH` in every worldview; generation fails otherwise.)
 //!
 //! Resolution of the shared key, in order:
 //!   1. worldview-agnostic override
-//!   2. the locale's Natural Earth field on the group's sovereign member —
-//!      required to agree across every worldview without a scoped override
-//!   3. hard error
+//!   2. the CLDR name for the group's sovereign `ISO_A2_EH`
+//!   3. hard error — no silent fallback
 //!
-//! Scoped overrides additionally emit the `<worldview>.<name_key>` keys.
+//! Overrides exist where CLDR has no usable entry (continents have no
+//! territory; a collapsed group has no sovereign `ISO_A2_EH`; NE-only
+//! aggregates like the Spratlys) or where CLDR's name is not the one we ship. A
+//! worldview-scoped override additionally emits a `<worldview>.<name_key>` key
+//! the app prefers — implemented for future admin-1 use, where a disputed
+//! region legitimately differs by political view.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -46,14 +50,16 @@ pub fn region_names_path(dir: &Path, locale: Locale) -> PathBuf {
 
 pub fn build_region_names(
     by_worldview: &[(Worldview, Vec<ParsedFeature>)],
+    cldr: &BTreeMap<Locale, BTreeMap<String, String>>,
     overrides: &Overrides,
 ) -> Result<BTreeMap<Locale, BTreeMap<String, String>>> {
-    // 1. Collect the entity key set + each country's sovereign localized names,
-    //    kept per worldview so divergence can be judged against the overrides.
+    // 1. Collect the entity key set + each country's sovereign `ISO_A2_EH` (the
+    //    CLDR join key). CLDR names don't depend on worldview, so we keep one
+    //    alpha-2 per ADM0_A3 and require every worldview carrying a sovereign
+    //    member to agree on it — a code must denote one territory.
     let mut continent_codes: BTreeSet<&'static str> = BTreeSet::new();
     let mut country_codes: BTreeSet<String> = BTreeSet::new();
-    let mut country_localized: BTreeMap<String, BTreeMap<Worldview, BTreeMap<String, String>>> =
-        BTreeMap::new();
+    let mut country_a2: BTreeMap<String, (String, &'static str)> = BTreeMap::new();
 
     for (worldview, features) in by_worldview {
         let mut groups: BTreeMap<&str, Vec<&ParsedFeature>> = BTreeMap::new();
@@ -65,11 +71,22 @@ pub fn build_region_names(
         }
         for (adm0, group) in &groups {
             country_codes.insert((*adm0).to_string());
-            if let Some(sov) = sovereign_member(group) {
-                country_localized
-                    .entry((*adm0).to_string())
-                    .or_default()
-                    .insert(*worldview, sov.localized_names.clone());
+            let a2 = sovereign_member(group)
+                .map(|sov| sov.iso_a2_eh.as_str())
+                .filter(|a2| *a2 != "-99");
+            if let Some(a2) = a2 {
+                match country_a2.get(*adm0) {
+                    None => {
+                        country_a2
+                            .insert((*adm0).to_string(), (a2.to_string(), worldview.spec().id));
+                    }
+                    Some((seen, seen_wv)) if seen != a2 => bail!(
+                        "ADM0_A3 `{adm0}` maps to different ISO_A2_EH across worldviews: \
+                         `{seen}` ({seen_wv}) vs `{a2}` ({}) — a code must denote one territory",
+                        worldview.spec().id
+                    ),
+                    Some(_) => {}
+                }
             }
         }
     }
@@ -90,29 +107,79 @@ pub fn build_region_names(
         );
     }
 
+    let mut cldr_by_a2: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for adm0 in &country_codes {
+        let key = format!("country.{adm0}");
+        let fully_overridden = Locale::ALL
+            .iter()
+            .all(|&l| overrides.get_default(&key, l).is_some());
+        if fully_overridden {
+            continue;
+        }
+        if let Some((a2, _)) = country_a2.get(adm0) {
+            cldr_by_a2
+                .entry(a2.as_str())
+                .or_default()
+                .push(adm0.as_str());
+        }
+    }
+    let collisions: Vec<String> = cldr_by_a2
+        .iter()
+        .filter(|(_, adms)| adms.len() > 1)
+        .map(|(a2, adms)| {
+            format!(
+                "ISO_A2_EH `{a2}` is shared by {} entities resolving via CLDR ({}) — CLDR names \
+                 each after territory `{a2}`; override all but the canonical one in \
+                 geo_names_overrides.toml",
+                adms.len(),
+                adms.join(", ")
+            )
+        })
+        .collect();
+    if !collisions.is_empty() {
+        bail!(
+            "region names have {} alpha-2 collision(s):\n  {}",
+            collisions.len(),
+            collisions.join("\n  ")
+        );
+    }
+
     // 3. Flat map per locale, plus worldview-prefixed keys for scoped overrides.
+    //    Every unfillable key is collected so a single run reports all gaps to
+    //    author, rather than one failure per rerun.
     let mut out: BTreeMap<Locale, BTreeMap<String, String>> = BTreeMap::new();
+    let mut missing: Vec<String> = Vec::new();
     for &locale in Locale::ALL {
+        let cldr_names = cldr.get(&locale).ok_or_else(|| {
+            anyhow!(
+                "no CLDR territories loaded for locale {}",
+                locale.spec().tag
+            )
+        })?;
         let mut names: BTreeMap<String, String> = BTreeMap::new();
 
         for code in &continent_codes {
             let key = format!("continent.{code}");
-            // Continents have no NE feature — the override is the ONLY source.
-            let name = overrides.get_default(&key, locale).ok_or_else(|| {
-                anyhow!(
-                    "no name for `{key}` (locale={}): continents are synthesized and have no \
-                     Natural Earth feature, so every continent name must be authored in \
-                     geo_names_overrides.toml",
+            match overrides.get_default(&key, locale) {
+                Some(name) => {
+                    names.insert(key, name.to_string());
+                }
+                None => missing.push(format!(
+                    "`{key}` (locale={}): continents are synthesized and have no CLDR territory — \
+                     author the name in geo_names_overrides.toml",
                     locale.spec().tag
-                )
-            })?;
-            names.insert(key, name.to_string());
+                )),
+            }
         }
 
         for adm0 in &country_codes {
             let key = format!("country.{adm0}");
-            let name = resolve_country_name(&key, adm0, locale, &country_localized, overrides)?;
-            names.insert(key, name);
+            match resolve_country_name(&key, adm0, locale, &country_a2, cldr_names, overrides) {
+                Ok(name) => {
+                    names.insert(key, name);
+                }
+                Err(e) => missing.push(e.to_string()),
+            }
         }
 
         // Worldview-scoped overrides → `<worldview>.<name_key>`, only where a
@@ -125,6 +192,13 @@ pub fn build_region_names(
 
         out.insert(locale, names);
     }
+    if !missing.is_empty() {
+        bail!(
+            "region names have {} unresolved gap(s):\n  {}",
+            missing.len(),
+            missing.join("\n  ")
+        );
+    }
     Ok(out)
 }
 
@@ -132,61 +206,27 @@ fn resolve_country_name(
     key: &str,
     adm0: &str,
     locale: Locale,
-    country_localized: &BTreeMap<String, BTreeMap<Worldview, BTreeMap<String, String>>>,
+    country_a2: &BTreeMap<String, (String, &'static str)>,
+    cldr_names: &BTreeMap<String, String>,
     overrides: &Overrides,
 ) -> Result<String> {
     if let Some(name) = overrides.get_default(key, locale) {
         return Ok(name.to_string());
     }
-    let ne_field = locale.spec().ne_field;
-    let by_worldview = country_localized.get(adm0);
-    let ne_name = |worldview: Worldview| -> Option<&str> {
-        by_worldview?
-            .get(&worldview)?
-            .get(ne_field)
-            .map(String::as_str)
-    };
-
-    // NE name -> worldviews carrying it, over the worldviews with no scoped
-    // override for this locale (the ones that resolve through the shared key).
-    let mut unscoped: BTreeMap<&str, Vec<&'static str>> = BTreeMap::new();
-    for &worldview in Worldview::ALL {
-        if overrides.get_scoped(key, worldview, locale).is_some() {
-            continue;
-        }
-        if let Some(name) = ne_name(worldview) {
-            unscoped.entry(name).or_default().push(worldview.spec().id);
-        }
-    }
-    match unscoped.len() {
-        1 => Ok(unscoped.keys().next().unwrap().to_string()),
-        0 => Worldview::ALL
-            .iter()
-            .find_map(|&worldview| ne_name(worldview))
-            .map(str::to_string)
-            .ok_or_else(|| {
-                anyhow!(
-                    "no name for `{key}` (locale={}): Natural Earth has no non-empty \
-                     `{ne_field}` on this group's sovereign member (a collapsed group with no \
-                     `TYPE == \"Country\"` member has none) — add an override to \
-                     geo_names_overrides.toml",
-                    locale.spec().tag
-                )
-            }),
-        _ => {
-            let variants = unscoped
-                .iter()
-                .map(|(name, worldviews)| format!("`{name}` ({})", worldviews.join(", ")))
-                .collect::<Vec<_>>()
-                .join(" vs ");
-            bail!(
-                "Natural Earth names for `{key}` (locale={}) diverge across worldviews sharing \
-                 the un-prefixed key: {variants} — author a worldview-scoped override \
-                 (`[\"{key}\".<worldview>]`) for the divergent worldviews, or a \
-                 worldview-agnostic override",
+    match country_a2.get(adm0) {
+        None => bail!(
+            "no name for `{key}` (locale={}): this group has no usable `ISO_A2_EH` (a collapsed \
+             group with no `TYPE == \"Country\"` member, or a `-99` sentinel), so it has no CLDR \
+             territory — add an override to geo_names_overrides.toml",
+            locale.spec().tag
+        ),
+        Some((a2, _)) => cldr_names.get(a2).cloned().ok_or_else(|| {
+            anyhow!(
+                "no name for `{key}` (locale={}): CLDR has no territory `{a2}` (ISO_A2_EH of this \
+                 group's sovereign member) — add an override to geo_names_overrides.toml",
                 locale.spec().tag
             )
-        }
+        }),
     }
 }
 

--- a/tools/geo_rasterizer/src/parse.rs
+++ b/tools/geo_rasterizer/src/parse.rs
@@ -1,10 +1,8 @@
 //! Parse Natural Earth admin-0 GeoJSON.
 
-use std::collections::BTreeMap;
 use std::path::Path;
 
 use anyhow::{anyhow, bail, Context, Result};
-use geo_data_format::Locale;
 use geo_types::{Geometry, MultiPolygon};
 
 /// One Natural Earth feature, with the fields the rasterizer needs.
@@ -16,6 +14,9 @@ pub struct ParsedFeature {
     /// `ISO_A3_EH` (de-facto-filled ISO alpha-3). Present for every feature;
     /// no `-99` in the shipped data.
     pub iso_a3_eh: String,
+    /// `ISO_A2_EH` (de-facto-filled ISO alpha-2). Present for every feature
+    /// (no `-99`); the key that joins this feature to its CLDR territory name.
+    pub iso_a2_eh: String,
     /// `NAME` (English). For logging/diagnostics.
     pub name: String,
     /// `TYPE` (NE feature class: "Country", "Sovereign country", "Geo unit",
@@ -30,10 +31,6 @@ pub struct ParsedFeature {
     pub region_un: String,
     /// Geometry as `MultiPolygon` (Polygons are wrapped to a 1-element MP for uniformity).
     pub geometry: MultiPolygon<f64>,
-    /// Localized names keyed by the Natural Earth property they came from
-    /// (`Locale::spec().ne_field`, e.g. `NAME_ZH`). Missing/empty values are
-    /// OMITTED, so a lookup miss means "NE has no name in that language here".
-    pub localized_names: BTreeMap<String, String>,
 }
 
 /// Parse a Natural Earth admin-0 countries GeoJSON for a given `worldview`, then
@@ -68,6 +65,11 @@ pub fn parse_geojson(path: &Path, worldview: &str) -> Result<Vec<ParsedFeature>>
             .and_then(|v| v.as_str())
             .unwrap_or("-99")
             .to_string();
+        let iso_a2_eh = props
+            .get("ISO_A2_EH")
+            .and_then(|v| v.as_str())
+            .unwrap_or("-99")
+            .to_string();
         let name = props
             .get("NAME")
             .and_then(|v| v.as_str())
@@ -99,25 +101,16 @@ pub fn parse_geojson(path: &Path, worldview: &str) -> Result<Vec<ParsedFeature>>
             Geometry::MultiPolygon(mp) => mp,
             _ => bail!("feature {idx} ({adm0_a3}): expected Polygon/MultiPolygon"),
         };
-        let mut localized_names = BTreeMap::new();
-        for &locale in Locale::ALL {
-            let field = locale.spec().ne_field;
-            if let Some(value) = props.get(field).and_then(|v| v.as_str()) {
-                if !value.is_empty() {
-                    localized_names.insert(field.to_string(), value.to_string());
-                }
-            }
-        }
         out.push(ParsedFeature {
             adm0_a3,
             iso_a3,
             iso_a3_eh,
+            iso_a2_eh,
             name,
             feature_type,
             continent,
             region_un,
             geometry: mp,
-            localized_names,
         });
     }
     crate::absorb::apply_absorptions(&mut out, worldview)?;

--- a/tools/geo_rasterizer/tests/entities.rs
+++ b/tools/geo_rasterizer/tests/entities.rs
@@ -25,12 +25,12 @@ fn feat(adm0: &str, continent: &str) -> ParsedFeature {
         adm0_a3: adm0.into(),
         iso_a3: adm0.into(),
         iso_a3_eh: adm0.into(),
+        iso_a2_eh: adm0.into(),
         name: adm0.into(),
         feature_type: "Country".into(),
         continent: continent.into(),
         region_un: "Africa".into(),
         geometry: MultiPolygon(vec![sq]),
-        localized_names: Default::default(),
     }
 }
 

--- a/tools/geo_rasterizer/tests/names.rs
+++ b/tools/geo_rasterizer/tests/names.rs
@@ -18,82 +18,108 @@ fn sq() -> MultiPolygon<f64> {
     )])
 }
 
-/// A single-feature `TYPE == "Country"` group in Asia, with the given zh name.
-fn feat(adm0: &str, zh: &str) -> ParsedFeature {
+/// A single-feature `TYPE == "Country"` group in Asia, joined to CLDR by `a2`.
+fn feat(adm0: &str, a2: &str) -> ParsedFeature {
     ParsedFeature {
         adm0_a3: adm0.into(),
         iso_a3: adm0.into(),
         iso_a3_eh: adm0.into(),
+        iso_a2_eh: a2.into(),
         name: adm0.into(),
         feature_type: "Country".into(),
         continent: "Asia".into(),
         region_un: "Asia".into(),
         geometry: sq(),
-        localized_names: BTreeMap::from([
-            ("NAME_EN".to_string(), adm0.to_string()),
-            ("NAME_ZH".to_string(), zh.to_string()),
-        ]),
     }
 }
 
-// Continents have no NE feature, so `AS` must be authored or generation errors.
+/// CLDR territories for both locales from `(alpha2, en, zh)` triples.
+fn cldr(pairs: &[(&str, &str, &str)]) -> BTreeMap<Locale, BTreeMap<String, String>> {
+    let mut en = BTreeMap::new();
+    let mut zh = BTreeMap::new();
+    for (a2, e, z) in pairs {
+        en.insert(a2.to_string(), e.to_string());
+        zh.insert(a2.to_string(), z.to_string());
+    }
+    BTreeMap::from([(Locale::EnUs, en), (Locale::ZhCn, zh)])
+}
+
+// Continents have no CLDR territory, so `AS` must be authored or generation errors.
 const OVERRIDES: &str = "[\"continent.AS\"]\nen-US = \"Asia\"\nzh-CN = \"亚洲\"\n";
 
 #[test]
-fn names_resolve_from_ne_fields_and_overrides() {
+fn names_resolve_from_cldr_and_overrides() {
     let ov = Overrides::from_toml_str(OVERRIDES).unwrap();
     let by = vec![
-        (Worldview::Iso, vec![feat("AAA", "甲国")]),
-        (Worldview::Chn, vec![feat("AAA", "甲国")]),
+        (Worldview::Iso, vec![feat("AAA", "AA")]),
+        (Worldview::Chn, vec![feat("AAA", "AA")]),
     ];
-    let out = build_region_names(&by, &ov).unwrap();
+    let out = build_region_names(&by, &cldr(&[("AA", "Aaa", "甲国")]), &ov).unwrap();
     assert_eq!(out[&Locale::ZhCn]["country.AAA"], "甲国");
-    assert_eq!(out[&Locale::EnUs]["country.AAA"], "AAA");
+    assert_eq!(out[&Locale::EnUs]["country.AAA"], "Aaa");
     assert_eq!(out[&Locale::ZhCn]["continent.AS"], "亚洲");
 }
 
 #[test]
-fn diverging_ne_names_across_worldviews_is_an_error() {
-    // The shared key holds one name; an uncovered cross-worldview divergence
-    // must fail loudly, not silently ship the first worldview's name to all.
+fn diverging_iso_a2_across_worldviews_is_an_error() {
+    // A code must denote one territory: the same ADM0_A3 mapping to different
+    // ISO_A2_EH across worldviews is a data fault, not a name to pick from.
     let ov = Overrides::from_toml_str(OVERRIDES).unwrap();
     let by = vec![
-        (Worldview::Iso, vec![feat("AAA", "甲国-iso")]),
-        (Worldview::Chn, vec![feat("AAA", "甲国-chn")]),
+        (Worldview::Iso, vec![feat("AAA", "AA")]),
+        (Worldview::Chn, vec![feat("AAA", "AB")]),
     ];
-    let err = build_region_names(&by, &ov).unwrap_err().to_string();
+    let err = build_region_names(
+        &by,
+        &cldr(&[("AA", "Aaa", "甲国"), ("AB", "Abb", "乙国")]),
+        &ov,
+    )
+    .unwrap_err()
+    .to_string();
     assert!(err.contains("AAA"), "got: {err}");
-    assert!(err.contains("diverge"), "got: {err}");
+    assert!(err.contains("ISO_A2_EH"), "got: {err}");
 }
 
 #[test]
-fn scoped_overrides_resolve_a_ne_divergence() {
-    // The escape hatch the divergence error advertises: scope the divergent
-    // worldview, and the remaining unscoped worldviews agree on the shared key.
+fn a_cldr_miss_without_override_is_an_error() {
+    // The join key resolves but CLDR carries no such territory (an NE-only
+    // aggregate) — must fail loudly, not ship a raw key.
+    let ov = Overrides::from_toml_str(OVERRIDES).unwrap();
+    let by = vec![(Worldview::Iso, vec![feat("AAA", "ZZ")])];
+    let err = build_region_names(&by, &cldr(&[("AA", "Aaa", "甲国")]), &ov)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("country.AAA"), "got: {err}");
+    assert!(err.contains("ZZ"), "got: {err}");
+}
+
+#[test]
+fn a_worldview_agnostic_override_beats_cldr() {
+    let toml = format!("{OVERRIDES}\n[\"country.AAA\"]\nzh-CN = \"乙国\"\n");
+    let ov = Overrides::from_toml_str(&toml).unwrap();
+    let by = vec![(Worldview::Iso, vec![feat("AAA", "AA")])];
+    let out = build_region_names(&by, &cldr(&[("AA", "Aaa", "甲国")]), &ov).unwrap();
+    // zh override wins; en falls through to CLDR (no en override, no leak).
+    assert_eq!(out[&Locale::ZhCn]["country.AAA"], "乙国");
+    assert_eq!(out[&Locale::EnUs]["country.AAA"], "Aaa");
+}
+
+#[test]
+fn a_scoped_override_emits_a_prefixed_key() {
+    // The worldview-scoped override path (future admin-1): a `<worldview>.<key>`
+    // key the app prefers, without disturbing the CLDR-resolved shared key.
     let toml = format!("{OVERRIDES}\n[\"country.AAA\".chn]\nzh-CN = \"甲国-chn\"\n");
     let ov = Overrides::from_toml_str(&toml).unwrap();
     let by = vec![
-        (Worldview::Iso, vec![feat("AAA", "甲国-iso")]),
-        (Worldview::Chn, vec![feat("AAA", "甲国-chn")]),
+        (Worldview::Iso, vec![feat("AAA", "AA")]),
+        (Worldview::Chn, vec![feat("AAA", "AA")]),
     ];
-    let out = build_region_names(&by, &ov).unwrap();
-    assert_eq!(out[&Locale::ZhCn]["country.AAA"], "甲国-iso");
-    assert_eq!(out[&Locale::ZhCn]["chn.country.AAA"], "甲国-chn");
-    // en-US names agree, and the zh-only scope must not leak into en-US.
-    assert_eq!(out[&Locale::EnUs]["country.AAA"], "AAA");
-    assert!(!out[&Locale::EnUs].contains_key("chn.country.AAA"));
-}
-
-#[test]
-fn a_worldview_agnostic_override_resolves_a_ne_divergence() {
-    let toml = format!("{OVERRIDES}\n[\"country.AAA\"]\nzh-CN = \"甲国\"\n");
-    let ov = Overrides::from_toml_str(&toml).unwrap();
-    let by = vec![
-        (Worldview::Iso, vec![feat("AAA", "甲国-iso")]),
-        (Worldview::Chn, vec![feat("AAA", "甲国-chn")]),
-    ];
-    let out = build_region_names(&by, &ov).unwrap();
+    let out = build_region_names(&by, &cldr(&[("AA", "Aaa", "甲国")]), &ov).unwrap();
     assert_eq!(out[&Locale::ZhCn]["country.AAA"], "甲国");
+    assert_eq!(out[&Locale::ZhCn]["chn.country.AAA"], "甲国-chn");
+    // The zh-only scope must not leak into en-US.
+    assert_eq!(out[&Locale::EnUs]["country.AAA"], "Aaa");
+    assert!(!out[&Locale::EnUs].contains_key("chn.country.AAA"));
 }
 
 #[test]
@@ -102,8 +128,10 @@ fn a_dead_override_key_is_an_error() {
     // silently as an unused key.
     let toml = format!("{OVERRIDES}\n[\"country.TWM\"]\nzh-CN = \"台湾\"\n");
     let ov = Overrides::from_toml_str(&toml).unwrap();
-    let by = vec![(Worldview::Iso, vec![feat("AAA", "甲国")])];
-    let err = build_region_names(&by, &ov).unwrap_err().to_string();
+    let by = vec![(Worldview::Iso, vec![feat("AAA", "AA")])];
+    let err = build_region_names(&by, &cldr(&[("AA", "Aaa", "甲国")]), &ov)
+        .unwrap_err()
+        .to_string();
     assert!(err.contains("country.TWM"), "got: {err}");
     assert!(err.contains("dead override"), "got: {err}");
 }
@@ -111,15 +139,17 @@ fn a_dead_override_key_is_an_error() {
 #[test]
 fn no_sovereign_and_no_override_is_an_error() {
     // A collapsed multi-member group with no `TYPE == "Country"` member has no
-    // NE name to take; without an override the shared key cannot be filled.
+    // sovereign ISO_A2_EH to join on; without an override the key cannot fill.
     let ov = Overrides::from_toml_str(OVERRIDES).unwrap();
     let dependency = |name: &str| ParsedFeature {
         feature_type: "Dependency".into(),
         name: name.into(),
-        ..feat("BBB", "乙国")
+        ..feat("BBB", "BB")
     };
     let by = vec![(Worldview::Iso, vec![dependency("b1"), dependency("b2")])];
-    let err = build_region_names(&by, &ov).unwrap_err().to_string();
+    let err = build_region_names(&by, &cldr(&[("BB", "Bbb", "乙国")]), &ov)
+        .unwrap_err()
+        .to_string();
     assert!(err.contains("country.BBB"), "got: {err}");
     assert!(err.contains("override"), "got: {err}");
 }
@@ -129,10 +159,10 @@ fn region_names_are_written_as_nested_json() {
     let toml = format!("{OVERRIDES}\n[\"country.AAA\".chn]\nzh-CN = \"甲国-chn\"\n");
     let ov = Overrides::from_toml_str(&toml).unwrap();
     let by = vec![
-        (Worldview::Iso, vec![feat("AAA", "甲国")]),
-        (Worldview::Chn, vec![feat("AAA", "甲国")]),
+        (Worldview::Iso, vec![feat("AAA", "AA")]),
+        (Worldview::Chn, vec![feat("AAA", "AA")]),
     ];
-    let out = build_region_names(&by, &ov).unwrap();
+    let out = build_region_names(&by, &cldr(&[("AA", "Aaa", "甲国")]), &ov).unwrap();
 
     let dir = tempfile::tempdir().unwrap();
     let path = write_region_names(dir.path(), Locale::ZhCn, &out[&Locale::ZhCn]).unwrap();


### PR DESCRIPTION
## Summary
Source region display names from Unicode CLDR (`territories.json`, pinned `48.2.0`) instead of Natural Earth's `NAME_*` columns. NE now supplies only geometry and the `ISO_A2_EH` code joining each entity to its CLDR name.

## Why
NE names are inconsistent (long/short forms, spelling variants) with a few wrong localized values; CLDR is the canonical, versioned, per-locale authority. CLDR names are worldview-independent, so the per-worldview name-divergence handling is dropped.

## Changes
- Pin CLDR by release tag + per-locale sha256 (`geo_data_format::cldr`); fetch/verify like the NE source.
- Resolve `country.<ADM0_A3>` via `ISO_A2_EH → CLDR`, overrides first.
- **Collision gate**: build fails if two entities resolve to the same alpha-2 — NE stamps sub-features with their sovereign's code, which would otherwise name e.g. Abkhazia "Georgia" (the coverage gate can't catch a non-empty-but-wrong name).
- Generation reports all name gaps + collisions in one run; `load_territories` fails fast on empty input.
- Overrides now cover only entities CLDR can't name (no ISO alpha-2: Bir Tawil, Spratlys, Cyprus base areas; sub-features: Abkhazia, S. Ossetia, …) or where CLDR's form is undesirable (Hong Kong, Macao, Palestine shortened).

## Verification
- All geo tests + clippy `-D warnings` green.
- Coverage gate: every entity across all 3 worldviews × 2 locales resolves to a non-empty name.
- Churn reviewed: canonical CLDR forms (China, United States, Türkiye, Czechia …); Taiwan / Hong Kong / Macau correctly absorbed into China in the `chn` worldview.