### PR TITLE
geo: absorb Scarborough Shoal into China in the chn worldview

### DIFF
--- a/tools/geo_rasterizer/geo_entity_registry.toml
+++ b/tools/geo_rasterizer/geo_entity_registry.toml
@@ -1146,7 +1146,7 @@ ref = [44.5369, 24.1223]
 code = "SCR"
 id = 244
 ref = [117.7538, 15.1521]
-worldview = ["chn", "usa"]
+worldview = ["usa"]
 
 [[country]]
 code = "SDN"

--- a/tools/geo_rasterizer/src/absorb.rs
+++ b/tools/geo_rasterizer/src/absorb.rs
@@ -3,7 +3,12 @@ use anyhow::{bail, Result};
 use crate::parse::ParsedFeature;
 
 /// `(worldview id, absorbed ADM0_A3, parent ADM0_A3)`.
-const ABSORPTIONS: &[(&str, &str, &str)] = &[("chn", "HKG", "CHN"), ("chn", "MAC", "CHN")];
+const ABSORPTIONS: &[(&str, &str, &str)] = &[
+    ("chn", "HKG", "CHN"),
+    ("chn", "MAC", "CHN"),
+    ("chn", "SCR", "CHN"),
+    // PGA is already absorbed into CHN
+];
 
 pub(crate) fn apply_absorptions(features: &mut Vec<ParsedFeature>, worldview: &str) -> Result<()> {
     let mut absorbed: Vec<(&'static str, geo_types::MultiPolygon<f64>)> = Vec::new();


### PR DESCRIPTION
## Summary
Fold Scarborough Shoal (`SCR`) into China in the `chn` worldview, like Hong Kong / Macau. It is a separate `Indeterminate` feature in the chn source; absorbing it removes the standalone entity from the chn bin and merges its geometry into `CHN`.

- Registry: `SCR` coverage reduced `["chn","usa"]` → `["usa"]`. `register_worldview` is additive (never shrinks), so the reduction is hand-applied and is stable across regeneration.
- `PGA` (the Spratlys) is already not a separate feature in the `chn` source (NE treats the area as China there), so it needs no absorption.

## Verification
- SCR bin membership: `iso=false, chn=false, usa=true` (was chn+usa).
- Registry regenerates identically (CI `git diff --exit-code` stable); clippy + all geo tests green.

> [!NOTE]
> Stacked on #373 (CLDR region names). **Merge #373 first**; until then this PR's diff includes the CLDR changes.