### PR TITLE
geo: return no entity for out-of-grid tile keys

### DIFF
--- a/app/rust/src/geo.rs
+++ b/app/rust/src/geo.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use anyhow::Result;
 use geo_data_format::{
     read_geo_data, tile_index, GeoData, GeoEntity, GeoEntityId, GeoEntityKind, PackedTile,
-    TileEntry, TileMembership,
+    TileEntry, TileMembership, TILE_GRID_WIDTH,
 };
 
 use crate::journey_bitmap::{BlockKey, TileKey};
@@ -56,6 +56,9 @@ impl GeoIndex {
     }
 
     fn tile_entry(&self, tile: TileKey) -> &TileEntry {
+        if tile.x as usize >= TILE_GRID_WIDTH || tile.y as usize >= TILE_GRID_WIDTH {
+            return &TileEntry::None;
+        }
         &self.data.tile_index[tile_index(tile.x, tile.y)]
     }
 

--- a/app/rust/tests/geo_lookup.rs
+++ b/app/rust/tests/geo_lookup.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use geo_data_format::{
     write_geo_data, GeoEntity, GeoEntityId, GeoEntityKind, TileMembership, Worldview,
-    CELLS_PER_TILE, TILE_COUNT,
+    CELLS_PER_TILE, TILE_COUNT, TILE_GRID_WIDTH,
 };
 use memolanes_core::{
     geo::{GeoIndex, GeoLookup},
@@ -21,11 +21,16 @@ fn entity(id: u32, kind: GeoEntityKind, iso: &str, parent: Option<u32>) -> GeoEn
     }
 }
 
+fn synthetic_geo() -> GeoIndex {
+    synthetic_geo_with_singles_at(&[])
+}
+
 /// Build a tiny worldview asset: continent EU(1) ⊃ {FR(2), DE(3)}, a `Single(FR)`
 /// tile at (0,0), and a `Border` tile at (1,0) whose blocks are filled x-major
 /// (`bx*128 + by`, the BlockKey convention) so block coords pass straight
-/// through `GeoLookup` with no transpose.
-fn synthetic_geo() -> GeoIndex {
+/// through `GeoLookup` with no transpose. `extra_singles` puts `Single(FR)` at
+/// further raw tile-grid indices.
+fn synthetic_geo_with_singles_at(extra_singles: &[usize]) -> GeoIndex {
     let entities = [
         entity(1, GeoEntityKind::Continent, "EU", None),
         entity(2, GeoEntityKind::Country, "FR", Some(1)),
@@ -35,6 +40,9 @@ fn synthetic_geo() -> GeoIndex {
     let mut tiles = vec![TileMembership::None; TILE_COUNT];
     tiles[0] = TileMembership::Single(GeoEntityId(2)); // (tx,ty)=(0,0) → idx 0
     tiles[512] = TileMembership::Border; // (tx,ty)=(1,0) → x-major idx tx*512+ty
+    for idx in extra_singles {
+        tiles[*idx] = TileMembership::Single(GeoEntityId(2));
+    }
 
     let mut cells = vec![None; CELLS_PER_TILE];
     cells[BlockKey::from_x_y(2, 3).index()] = Some(GeoEntityId(3)); // DE
@@ -102,6 +110,84 @@ fn tile_membership_does_not_decode() {
         geo.tile_membership(TileKey::new(2, 0)),
         TileMembership::None
     );
+}
+
+/// Tile keys real `add_line` calls produce past the Mercator latitude limit
+/// (±85.0511°): `journey_bitmap` masks tile x to the map width but never masks
+/// tile y, and nothing clamps latitude. South of the limit y runs off the
+/// 512-tile grid; north of it the Mercator y goes negative and `as u16` wraps.
+/// x*512 + y lands past the grid only for a big enough x, so the rest alias
+/// onto an unrelated in-grid tile instead of panicking.
+const OUT_OF_GRID_PAST_END: [(u16, u16); 2] = [
+    (511, 529),   // lng 179.5°, lat -86.0° → raw index 262161
+    (426, 65462), // lng 120°, lat 88° → raw index 283574
+];
+const OUT_OF_GRID_ALIASING: [(u16, u16); 2] = [
+    (256, 552),   // lng 0°, lat -87° → raw index 131624
+    (256, 65461), // lng 0°, lat 88° → raw index 196533
+];
+
+#[test]
+fn out_of_grid_tile_key_does_not_index_past_the_tile_grid() {
+    let geo = synthetic_geo();
+    for (x, y) in OUT_OF_GRID_PAST_END {
+        let key = TileKey::new(x, y);
+        assert_eq!(
+            geo.entity_of_block(key, BlockKey::from_x_y(0, 0)),
+            None,
+            "tile ({x},{y})"
+        );
+        assert_eq!(
+            geo.tile_membership(key),
+            TileMembership::None,
+            "tile ({x},{y})"
+        );
+    }
+}
+
+#[test]
+fn out_of_grid_tile_key_is_not_aliased_onto_an_in_grid_tile() {
+    // Seed the tiles those raw indices land on, so an unguarded lookup reports
+    // their owner instead of quietly reading an empty tile.
+    let aliased: Vec<usize> = OUT_OF_GRID_ALIASING
+        .iter()
+        .map(|(x, y)| *x as usize * TILE_GRID_WIDTH + *y as usize)
+        .collect();
+    let geo = synthetic_geo_with_singles_at(&aliased);
+
+    for (x, y) in OUT_OF_GRID_ALIASING {
+        let key = TileKey::new(x, y);
+        assert_eq!(
+            geo.entity_of_block(key, BlockKey::from_x_y(0, 0)),
+            None,
+            "tile ({x},{y})"
+        );
+        assert_eq!(
+            geo.tile_membership(key),
+            TileMembership::None,
+            "tile ({x},{y})"
+        );
+    }
+}
+
+#[test]
+fn out_of_grid_tile_x_resolves_to_none() {
+    // `of_tile_bytes_without_validation` takes tile keys verbatim from a FoW
+    // import file, so x can be out of the grid too — no projection involved.
+    let geo = synthetic_geo();
+    for (x, y) in [(TILE_GRID_WIDTH as u16, 0), (u16::MAX, u16::MAX)] {
+        let key = TileKey::new(x, y);
+        assert_eq!(
+            geo.entity_of_block(key, BlockKey::from_x_y(0, 0)),
+            None,
+            "tile ({x},{y})"
+        );
+        assert_eq!(
+            geo.tile_membership(key),
+            TileMembership::None,
+            "tile ({x},{y})"
+        );
+    }
 }
 
 #[test]

--- a/app/rust/tests/region_ground_truth.rs
+++ b/app/rust/tests/region_ground_truth.rs
@@ -23,7 +23,7 @@ use std::fs;
 use chrono::NaiveDate;
 use geo_data_format::{GeoEntityKind, Worldview};
 use memolanes_core::{
-    achievement::compute::region_state::RegionStateMap,
+    achievement::compute::region_state::{compute_region_states, RegionStateMap},
     achievement::layer::AchievementLayer,
     achievement::read_model::region::{
         region_detail, region_level_view, region_levels, RegionKind,
@@ -175,6 +175,15 @@ fn sub(dir: &TempDir, s: &str) -> String {
     let p = dir.path().join(s);
     fs::create_dir_all(&p).unwrap();
     p.into_os_string().into_string().unwrap()
+}
+
+/// Canonical codes of every credited entity, any kind, any layer.
+fn credited_codes(states: &RegionStateMap, geo: &dyn GeoLookup) -> BTreeSet<String> {
+    states
+        .keys()
+        .filter_map(|(_, id)| geo.entity(*id))
+        .map(|e| e.canonical_code.clone())
+        .collect()
 }
 
 /// ISO codes of all visited entities of kind Country, for one layer.
@@ -346,4 +355,23 @@ fn region_api_reports_correct_countries_and_areas() {
             Ok(())
         })
         .unwrap();
+}
+
+/// Past the Mercator limit (±85.0511°) `add_line` produces tile keys outside the
+/// 512×512 grid: y ≥ 512 in the south, and in the north a negative Mercator y
+/// wrapped through `as u16` to ~65461. Their raw `x*512 + y` is not a safe index
+/// — with the real asset a track at 88°N resolves to tile (383,437), which is
+/// `Single(ATA)`, so the North Pole gets credited to Antarctica, and a track at
+/// 88°N/120°E indexes past the tile grid entirely.
+#[test]
+fn track_past_the_mercator_limit_credits_nothing() {
+    let geo = GeoIndex::from_bytes(&fs::read(test_utils::geo_asset("iso")).unwrap()).unwrap();
+
+    for (lng, lat) in [(0.0, 88.0), (120.0, 88.0), (0.0, -87.0)] {
+        let mut bitmap = JourneyBitmap::new();
+        bitmap.add_line(lng, lat, lng + 0.01, lat + 0.01);
+        let states = compute_region_states([(AchievementLayer::All, bitmap)], &geo);
+        let credited = credited_codes(&states, &geo);
+        assert!(credited.is_empty(), "({lng}, {lat}) credited {credited:?}");
+    }
 }


### PR DESCRIPTION
`GeoIndex::tile_entry` indexed the 512×512 tile grid with `x * 512 + y` without checking that either coordinate was actually inside it. Two independent routes produce keys that are not:

1. `add_line` masks tile x to the map width but never masks tile y, and nothing clamps latitude. Past the Mercator limit (±85.0511°) a track yields `y >= 512` in the south; in the north the Mercator y goes negative and wraps through `as u16` to ~65461.
2. `of_tile_bytes_without_validation` takes both coordinates verbatim from an import file, no projection involved, so x can be out of the grid too. That is why the guard checks both axes rather than just y.

The panic is the smaller harm. `x * 512 + y` only runs past the index for a large enough x (lng ≳ 90.7°E in the north, ≳ 179.3°E in the south):

```
panicked at src/geo.rs:59:30:
index out of bounds: the len is 262144 but the index is 262161
```

Everywhere else the index lands back inside the grid and the lookup silently succeeds against an unrelated tile. The aliasing is systematic — southern keys map into the Arctic band, northern ones into the Antarctic band about 89° east. Against the real `iso` asset, a track at 88°N resolves to tile (383,437), which is `Single(ATA)`, so the North Pole was credited to Antarctica, and the ancestor roll-up carried that up to the continent as well.

Out-of-grid keys now resolve to `TileEntry::None`. That is the only truthful answer available: the geo asset is rasterized onto the same 512×512 grid, so no cell exists beyond ±85.0511° to credit. `total_area_m2` is summed over the same cells (`geo_rasterizer/src/area.rs`), so numerator and denominator stay consistent and full coverage of a region remains reachable. Region states are computed on demand, so existing installs correct themselves on the next read — no migration, no cache invalidation, no `GEO_DATA_VERSION` bump.

## Tests

- `geo_lookup.rs` — both routes over synthetic geo, using the tile keys real `add_line` calls produce. The aliasing case seeds an entity at the raw index the bad key lands on, so an unguarded lookup returns that entity instead of quietly reading an empty tile.
- `region_ground_truth.rs` — end to end over the real asset: `add_line` at 88°N / 88°N,120°E / 87°S must credit nothing. Fails before the change with `(0, 88) credited {"AN", "ATA"}`.

## Out of scope

Root-causing is left for follow-ups: whether `lng_lat_to_tile_x_y` (or `add_line`) should clamp latitude, whether ingest should reject `|lat| > 85.0511°`, and whether the import path should validate tile keys.

Worth noting separately: `export_data/fow.rs:391` has the same defect and panics today on the same data (`index out of bounds: the len is 32768 but the index is 35360` for a track at 87°S). Not fixed here.