### PR TITLE
Fix globe rendering and Android WebView map assets

### DIFF
--- a/app/journey_kernel/static/layers/canvas-pole-foggy-layer.ts
+++ b/app/journey_kernel/static/layers/canvas-pole-foggy-layer.ts
@@ -1,0 +1,222 @@
+import type {
+  CustomLayerInterface,
+  CustomRenderMethodInput,
+  Map as MaplibreMap,
+} from "maplibre-gl";
+import type { RGBAColor } from "./journey-layer-interface";
+import { getViewportTileRange } from "./utils";
+
+type ProjectionUniforms = {
+  clippingPlane: WebGLUniformLocation | null;
+  transition: WebGLUniformLocation | null;
+  tileMercatorCoords: WebGLUniformLocation | null;
+  matrix: WebGLUniformLocation | null;
+  fallbackMatrix: WebGLUniformLocation | null;
+};
+
+const NORTH_POLE_Y = -32768;
+const SOUTH_POLE_Y = 32767;
+
+/** Minimal pole-only renderer used by Canvas mode. */
+export class CanvasPoleFoggyLayer implements CustomLayerInterface {
+  readonly id: string;
+  readonly type = "custom" as const;
+  readonly renderingMode = "2d" as const;
+
+  private readonly map: MaplibreMap;
+  private readonly bgColor: Float32Array;
+  private program: WebGLProgram | null = null;
+  private buffer: WebGLBuffer | null = null;
+  private aPos?: number;
+  private uBgColor: WebGLUniformLocation | null = null;
+  private projectionUniforms?: ProjectionUniforms;
+  private meshKey = "";
+  private poleMesh = new Float32Array();
+  private uploadedPoleMesh: Float32Array | null = null;
+
+  constructor(map: MaplibreMap, id: string, bgColor: RGBAColor) {
+    this.map = map;
+    this.id = id;
+    const [r, g, b, a] = bgColor;
+    this.bgColor = new Float32Array([r * a, g * a, b * a, a]);
+  }
+
+  onAdd(): void {}
+
+  onRemove(
+    _map: MaplibreMap,
+    gl: WebGLRenderingContext | WebGL2RenderingContext,
+  ): void {
+    if (this.program) gl.deleteProgram(this.program);
+    if (this.buffer) gl.deleteBuffer(this.buffer);
+    this.program = null;
+    this.buffer = null;
+    this.uBgColor = null;
+    this.projectionUniforms = undefined;
+    this.uploadedPoleMesh = null;
+    this.meshKey = "";
+    this.poleMesh = new Float32Array();
+  }
+
+  render(
+    gl: WebGLRenderingContext | WebGL2RenderingContext,
+    args: CustomRenderMethodInput,
+  ): void {
+    if (args.shaderData.variantName !== "globe") return;
+
+    if (!this.program) this.setupShader(gl, args);
+    if (
+      !this.program ||
+      !this.buffer ||
+      this.aPos === undefined ||
+      !this.projectionUniforms ||
+      !this.uBgColor
+    ) {
+      return;
+    }
+
+    const projection = args.defaultProjectionData;
+    const uniforms = this.projectionUniforms;
+
+    gl.useProgram(this.program);
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+    gl.uniform4f(uniforms.clippingPlane, ...projection.clippingPlane);
+    gl.uniform1f(uniforms.transition, projection.projectionTransition);
+    gl.uniform4f(uniforms.tileMercatorCoords, ...projection.tileMercatorCoords);
+    gl.uniformMatrix4fv(uniforms.matrix, false, projection.mainMatrix);
+    gl.uniformMatrix4fv(
+      uniforms.fallbackMatrix,
+      false,
+      projection.fallbackMatrix,
+    );
+    gl.uniform4fv(this.uBgColor, this.bgColor);
+
+    const poleMesh = this.getPoleMesh();
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.buffer);
+    if (this.uploadedPoleMesh !== poleMesh) {
+      gl.bufferData(gl.ARRAY_BUFFER, poleMesh, gl.STATIC_DRAW);
+      this.uploadedPoleMesh = poleMesh;
+    }
+    gl.enableVertexAttribArray(this.aPos);
+    gl.vertexAttribPointer(this.aPos, 2, gl.FLOAT, false, 0, 0);
+    gl.drawArrays(gl.TRIANGLES, 0, poleMesh.length / 2);
+  }
+
+  private getPoleMesh(): Float32Array {
+    const [x, y, w, h, z] = getViewportTileRange(this.map, true);
+    const worldTiles = Math.pow(2, z);
+    // Match MapLibre's globe tile subdivision closely enough to keep the
+    // Mercator boundary smooth, without depending on its private internals.
+    const granularity = Math.max(Math.floor(128 / worldTiles), 32);
+    const key = `${x}/${y}/${w}/${h}/${z}/${granularity}`;
+    if (key === this.meshKey) return this.poleMesh;
+
+    const drawNorthPole = y === 0;
+    const drawSouthPole = y + h === worldTiles;
+    const vertices: number[] = [];
+    const step = 1 / worldTiles / granularity;
+
+    const appendPole = (poleY: number, edgeY: number): void => {
+      for (let tileX = x; tileX < x + w; tileX++) {
+        const offset = tileX / worldTiles;
+        for (let segment = 0; segment < granularity; segment++) {
+          const low = offset + segment * step;
+          const high = low + step;
+          vertices.push(low, edgeY, high, edgeY, (low + high) / 2, poleY);
+        }
+      }
+    };
+
+    if (drawNorthPole) appendPole(NORTH_POLE_Y, 0);
+    if (drawSouthPole) appendPole(SOUTH_POLE_Y, 1);
+
+    this.meshKey = key;
+    this.poleMesh = new Float32Array(vertices);
+    return this.poleMesh;
+  }
+
+  private setupShader(
+    gl: WebGLRenderingContext | WebGL2RenderingContext,
+    args: CustomRenderMethodInput,
+  ): void {
+    const vertexSource = `#version 300 es
+      ${args.shaderData.vertexShaderPrelude}
+      ${args.shaderData.define}
+      in vec2 a_pos;
+      void main() {
+        gl_Position = projectTile(a_pos, a_pos);
+      }`;
+    const fragmentSource = `#version 300 es
+      precision mediump float;
+      uniform vec4 u_bgColor;
+      out highp vec4 fragColor;
+      void main() {
+        fragColor = u_bgColor;
+      }`;
+
+    const vertexShader = this.compileShader(gl, gl.VERTEX_SHADER, vertexSource);
+    const fragmentShader = this.compileShader(
+      gl,
+      gl.FRAGMENT_SHADER,
+      fragmentSource,
+    );
+    if (!vertexShader || !fragmentShader) return;
+
+    const program = gl.createProgram();
+    if (!program) return;
+    gl.attachShader(program, vertexShader);
+    gl.attachShader(program, fragmentShader);
+    gl.linkProgram(program);
+    gl.deleteShader(vertexShader);
+    gl.deleteShader(fragmentShader);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      console.error(
+        "CanvasPoleFoggyLayer program link failed:",
+        gl.getProgramInfoLog(program),
+      );
+      gl.deleteProgram(program);
+      return;
+    }
+
+    this.program = program;
+    this.aPos = gl.getAttribLocation(program, "a_pos");
+    this.uBgColor = gl.getUniformLocation(program, "u_bgColor");
+    this.projectionUniforms = {
+      clippingPlane: gl.getUniformLocation(
+        program,
+        "u_projection_clipping_plane",
+      ),
+      transition: gl.getUniformLocation(program, "u_projection_transition"),
+      tileMercatorCoords: gl.getUniformLocation(
+        program,
+        "u_projection_tile_mercator_coords",
+      ),
+      matrix: gl.getUniformLocation(program, "u_projection_matrix"),
+      fallbackMatrix: gl.getUniformLocation(
+        program,
+        "u_projection_fallback_matrix",
+      ),
+    };
+    this.buffer = gl.createBuffer();
+  }
+
+  private compileShader(
+    gl: WebGLRenderingContext | WebGL2RenderingContext,
+    type: number,
+    source: string,
+  ): WebGLShader | null {
+    const shader = gl.createShader(type);
+    if (!shader) return null;
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (gl.getShaderParameter(shader, gl.COMPILE_STATUS)) return shader;
+
+    console.error(
+      "CanvasPoleFoggyLayer shader compilation failed:",
+      gl.getShaderInfoLog(shader),
+    );
+    gl.deleteShader(shader);
+    return null;
+  }
+}

--- a/app/journey_kernel/static/layers/journey-canvas-layer.ts
+++ b/app/journey_kernel/static/layers/journey-canvas-layer.ts
@@ -5,6 +5,7 @@ import type { TileBuffer } from "../../pkg/journey_kernel.js";
 import type { JourneyTileProvider } from "../journey-tile-provider";
 import { JOURNEY_LAYER_ID } from "./journey-layer-interface";
 import type { JourneyLayer, RGBAColor } from "./journey-layer-interface";
+import { CanvasPoleFoggyLayer } from "./canvas-pole-foggy-layer";
 
 /**
  * Tile buffer callback function type
@@ -30,6 +31,7 @@ export class JourneyCanvasLayer implements JourneyLayer {
   private journeyTileProvider: JourneyTileProvider;
   private layerId: string;
   private sourceId: string;
+  private poleLayer: CanvasPoleFoggyLayer;
   private bgColor: string;
   private fgColor: string;
   private canvas: HTMLCanvasElement;
@@ -47,6 +49,11 @@ export class JourneyCanvasLayer implements JourneyLayer {
     this.journeyTileProvider = journeyTileProvider;
     this.layerId = layerId;
     this.sourceId = `${layerId}-canvas-source`;
+    this.poleLayer = new CanvasPoleFoggyLayer(
+      map,
+      `${layerId}-canvas-poles`,
+      bgColor,
+    );
 
     let r = Math.round(bgColor[0] * 255);
     let g = Math.round(bgColor[1] * 255);
@@ -82,6 +89,11 @@ export class JourneyCanvasLayer implements JourneyLayer {
         "raster-fade-duration": 0,
       },
     });
+
+    // Canvas/Image sources deliberately disable MapLibre's globe pole mesh.
+    // The Canvas-owned pole mesh meets the texture exactly at the Mercator
+    // edge, avoiding a translucent overlap band.
+    this.map.addLayer(this.poleLayer);
 
     this._repaintCallback = (
       x: number,
@@ -214,6 +226,10 @@ export class JourneyCanvasLayer implements JourneyLayer {
   remove(): void {
     if (this.map.getLayer(this.layerId)) {
       this.map.removeLayer(this.layerId);
+    }
+
+    if (this.map.getLayer(this.poleLayer.id)) {
+      this.map.removeLayer(this.poleLayer.id);
     }
 
     if (this.map.getSource(this.sourceId)) {

--- a/app/journey_kernel/static/layers/utils.ts
+++ b/app/journey_kernel/static/layers/utils.ts
@@ -20,14 +20,19 @@ export function tileXYToLngLat(x: number, y: number, zoom: number): LngLat {
 
 /* Get the range of tiles that covers the current map viewport
  * @param {Object} map - Mapbox map object
+ * @param {Boolean} isGlobeProjection - Whether the map uses globe projection
+ * @param {Number} maxZ - Optional maximum zoom level to cap the result
  * @returns {Array} - Array of [x, y, w, h, z] representing the tile range
  */
 export function getViewportTileRange(
   map: MaplibreMap,
   isGlobeProjection: boolean,
+  maxZ?: number,
 ): [number, number, number, number, number] {
   // Get the current zoom level
-  const z = Math.max(0, Math.floor(map.getZoom()));
+  // Apply maxZ cap only if maxZ is provided
+  const rawZ = Math.max(0, Math.floor(map.getZoom()));
+  const z = maxZ !== undefined ? Math.min(maxZ, rawZ) : rawZ;
 
   // Get the bounds of the map
   const bounds = map.getBounds();

--- a/app/journey_kernel/static/map-controller.ts
+++ b/app/journey_kernel/static/map-controller.ts
@@ -34,10 +34,7 @@ import type { JourneyLayer } from "./layers/journey-layer-interface";
 const MAX_MAP_ZOOM = 14;
 
 maplibregl.setWorkerUrl(
-  new URL(
-    "maplibre-gl/dist/maplibre-gl-worker.mjs",
-    import.meta.url,
-  ).toString(),
+  new URL("./maplibre-gl-worker.js", window.location.href).toString(),
 );
 
 /**

--- a/app/journey_kernel/static/utils.ts
+++ b/app/journey_kernel/static/utils.ts
@@ -110,6 +110,11 @@ export function transformStyleWithProjection(
   return {
     ...convertedStyle,
     projection: { type: projectionValue },
+    sky: {
+      "sky-color": "#080820",
+      "horizon-color": "#2a2a3a",
+      "atmosphere-blend": 0.8,
+    },
   };
 }
 

--- a/app/journey_kernel/webpack.config.js
+++ b/app/journey_kernel/webpack.config.js
@@ -16,15 +16,28 @@ module.exports = (env, argv) => {
       filename: "index.html",
       chunks: ["main"], // Only include the main chunk
     }),
-    // MapLibre v6's ESM worker imports this sibling module at runtime.
+    // Android's WebView asset loader serves unknown extensions as text/plain,
+    // so use .js for MapLibre's ESM worker and its imported sibling module.
     new CopyWebpackPlugin({
       patterns: [
         {
           from: path.resolve(
             __dirname,
+            "node_modules/maplibre-gl/dist/maplibre-gl-worker.mjs",
+          ),
+          to: "maplibre-gl-worker.js",
+          transform(content) {
+            return content
+              .toString()
+              .replaceAll("maplibre-gl-shared.mjs", "maplibre-gl-shared.js");
+          },
+        },
+        {
+          from: path.resolve(
+            __dirname,
             "node_modules/maplibre-gl/dist/maplibre-gl-shared.mjs",
           ),
-          to: "maplibre-gl-shared.mjs",
+          to: "maplibre-gl-shared.js",
         },
       ],
     }),

--- a/app/lib/body/settings/render_diagnostics.dart
+++ b/app/lib/body/settings/render_diagnostics.dart
@@ -4,6 +4,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:memolanes/common/component/capsule_style_app_bar.dart';
+import 'package:memolanes/common/map_webview_assets.dart';
 import 'package:memolanes/src/rust/api/api.dart' as api;
 
 class RenderDiagnosticsPage extends StatefulWidget {
@@ -25,8 +26,7 @@ class _RenderDiagnosticsPageState extends State<RenderDiagnosticsPage> {
 
   Future<void> _onWebViewCreated(InAppWebViewController controller) async {
     _controller = controller;
-    await controller.loadFile(
-        assetFilePath: 'assets/map_webview/render_diagnostics.html');
+    await MapWebViewAssets.load(controller, 'render_diagnostics.html');
   }
 
   Future<
@@ -86,6 +86,7 @@ class _RenderDiagnosticsPageState extends State<RenderDiagnosticsPage> {
           allowFileAccessFromFileURLs: true,
           allowUniversalAccessFromFileURLs: true,
           resourceCustomSchemes: ['memolanes'],
+          webViewAssetLoader: MapWebViewAssets.createAssetLoader(),
         ),
         onWebViewCreated: (controller) {
           _onWebViewCreated(controller);
@@ -98,6 +99,8 @@ class _RenderDiagnosticsPageState extends State<RenderDiagnosticsPage> {
             contentEncoding: 'utf-8',
             statusCode: result.status,
             headers: {
+              'Access-Control-Allow-Origin': '*',
+              'Access-Control-Expose-Headers': 'X-Tile-Version, X-Not-Modified',
               'Content-Type': result.contentType,
               ...result.headers,
             },

--- a/app/lib/common/component/base_map_webview.dart
+++ b/app/lib/common/component/base_map_webview.dart
@@ -9,6 +9,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:memolanes/common/gps_manager.dart';
 import 'package:memolanes/common/log.dart';
 import 'package:memolanes/common/map_style.dart';
+import 'package:memolanes/common/map_webview_assets.dart';
 import 'package:memolanes/common/mmkv_util.dart';
 import 'package:memolanes/src/rust/api/api.dart' as api;
 import 'package:memolanes/src/rust/utils.dart' as rust_utils show MapBounds;
@@ -287,17 +288,17 @@ class BaseMapWebviewState extends State<BaseMapWebview> {
 
     if (!mounted) return;
 
-    // Load the page after listeners are registered
+    // Load the page after listeners are registered. Platform-specific asset
+    // mechanics are isolated in MapWebViewAssets.
     if (_devServer.isNotEmpty) {
-      final devUrl = _devServer.endsWith('/')
+      final pageUrl = _devServer.endsWith('/')
           ? '${_devServer}index.html'
           : '$_devServer/index.html';
-      log.info('[base_map_webview] Loading from dev server: $devUrl');
-      await controller.loadUrl(urlRequest: URLRequest(url: WebUri(devUrl)));
+      log.info('[base_map_webview] Loading map page: $pageUrl');
+      await controller.loadUrl(urlRequest: URLRequest(url: WebUri(pageUrl)));
     } else {
-      final assetPath = 'assets/map_webview/index.html';
-      log.info('[base_map_webview] Loading asset: $assetPath');
-      await controller.loadFile(assetFilePath: assetPath);
+      log.info('[base_map_webview] Loading bundled map page');
+      await MapWebViewAssets.load(controller, 'index.html');
     }
   }
 
@@ -444,6 +445,7 @@ class BaseMapWebviewState extends State<BaseMapWebview> {
                 allowFileAccessFromFileURLs: true,
                 allowUniversalAccessFromFileURLs: true,
                 resourceCustomSchemes: ['memolanes'],
+                webViewAssetLoader: MapWebViewAssets.createAssetLoader(),
               ),
               onWebViewCreated: (controller) {
                 _onWebViewCreated(controller);
@@ -458,6 +460,9 @@ class BaseMapWebviewState extends State<BaseMapWebview> {
                   contentEncoding: 'utf-8',
                   statusCode: result.status,
                   headers: {
+                    'Access-Control-Allow-Origin': '*',
+                    'Access-Control-Expose-Headers':
+                        'X-Tile-Version, X-Not-Modified',
                     'Content-Type': result.contentType,
                     ...result.headers,
                   },
@@ -495,7 +500,10 @@ class BaseMapWebviewState extends State<BaseMapWebview> {
                   return NavigationActionPolicy.CANCEL;
                 }
                 final scheme = url.scheme;
-                if (scheme == 'file' || scheme == 'about') {
+                if (scheme == 'about') {
+                  return NavigationActionPolicy.ALLOW;
+                }
+                if (MapWebViewAssets.owns(url)) {
                   return NavigationActionPolicy.ALLOW;
                 }
                 if (_devServer.isNotEmpty &&

--- a/app/lib/common/map_webview_assets.dart
+++ b/app/lib/common/map_webview_assets.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+/// Loads bundled map assets without opening a localhost listening socket.
+///
+/// Android needs WebViewAssetLoader's virtual HTTPS origin for MapLibre module
+/// workers, while WKWebView can load the same bundle directly from Flutter
+/// assets. The platform difference stays isolated in this adapter.
+class MapWebViewAssets {
+  MapWebViewAssets._();
+
+  static const _assetRoot = 'assets/map_webview';
+  static const _androidAssetDomain = 'appassets.androidplatform.net';
+  static const _androidAssetBaseUrl =
+      'https://$_androidAssetDomain/assets/flutter_assets/$_assetRoot/';
+
+  static WebViewAssetLoader? createAssetLoader() {
+    if (!Platform.isAndroid) return null;
+    return WebViewAssetLoader(
+      domain: _androidAssetDomain,
+      pathHandlers: [AssetsPathHandler(path: '/assets/')],
+    );
+  }
+
+  static Future<void> load(
+    InAppWebViewController controller,
+    String fileName,
+  ) async {
+    if (Platform.isAndroid) {
+      await controller.loadUrl(
+        urlRequest: URLRequest(
+          url: WebUri('$_androidAssetBaseUrl$fileName'),
+        ),
+      );
+      return;
+    }
+
+    await controller.loadFile(assetFilePath: '$_assetRoot/$fileName');
+  }
+
+  static bool owns(WebUri url) => Platform.isAndroid
+      ? url.toString().startsWith(_androidAssetBaseUrl)
+      : url.scheme == 'file';
+}


### PR DESCRIPTION
- Add a canvas-rendered pole/foggy layer to prevent globe edge artifacts.
- Load MapLibre workers and bundled map assets through Android-compatible WebView URLs.
- Centralize platform-specific map asset loading and expose tile response headers for diagnostics.