### PR TITLE
UI v2 part 1: introduce design system and shared interactions

### DIFF
--- a/app/lib/body/first_launch_setup.dart
+++ b/app/lib/body/first_launch_setup.dart
@@ -2,10 +2,13 @@ import 'dart:io';
 
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:memolanes/common/component/app_button.dart';
+import 'package:memolanes/common/component/app_checkbox.dart';
 import 'package:memolanes/common/component/setup_bottom_sheet.dart';
 import 'package:memolanes/common/mmkv_util.dart';
 import 'package:memolanes/common/region_preference.dart';
 import 'package:memolanes/common/utils.dart';
+import 'package:memolanes/constants/app_typography.dart';
 import 'package:memolanes/constants/style_constants.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
@@ -33,17 +36,12 @@ Future<void> _showPrivacyAndRegionSheet(
   // A little weird, but shouldn't happen.
   if (!context.mounted) return;
 
-  final accepted = await showModalBottomSheet<_FirstLaunchAccepted>(
-    context: context,
-    backgroundColor: Colors.transparent,
-    isScrollControlled: true,
-    isDismissible: false,
-    enableDrag: false,
-    builder: (context) {
-      return FirstLaunchSetupSheet(
-        initialPrivacyAccepted: privacyAlreadyAccepted,
-      );
-    },
+  final accepted = await showSetupCard<_FirstLaunchAccepted>(
+    context,
+    barrierDismissible: false,
+    child: FirstLaunchSetupSheet(
+      initialPrivacyAccepted: privacyAlreadyAccepted,
+    ),
   );
 
   if (accepted == null) {
@@ -137,23 +135,14 @@ class _FirstLaunchSetupSheetState extends State<FirstLaunchSetupSheet> {
       title: context.tr("privacy.setup_title"),
       maxHeightFactor: 0.75,
       actions: [
-        OutlinedButton(
+        AppButton(
+          label: context.tr("privacy.disagree_and_exit"),
           onPressed: _onDisagree,
-          style: OutlinedButton.styleFrom(
-            foregroundColor: Colors.white,
-            side: const BorderSide(color: Color(0xFFB5B5B5)),
-            padding: const EdgeInsets.symmetric(vertical: 12),
-          ),
-          child: Text(context.tr("privacy.disagree_and_exit")),
+          variant: AppButtonVariant.secondary,
         ),
-        FilledButton(
+        AppButton(
+          label: context.tr("common.continue"),
           onPressed: _privacyAccepted ? _onContinue : null,
-          style: FilledButton.styleFrom(
-            backgroundColor: StyleConstants.defaultColor,
-            foregroundColor: Colors.black,
-            padding: const EdgeInsets.symmetric(vertical: 12),
-          ),
-          child: Text(context.tr("common.continue")),
         ),
       ],
       child: Column(
@@ -163,10 +152,8 @@ class _FirstLaunchSetupSheetState extends State<FirstLaunchSetupSheet> {
             padding: const EdgeInsets.only(bottom: 10),
             child: Text(
               context.tr("privacy.setup_desc"),
-              style: const TextStyle(
-                color: Color(0xFFB0B0B0),
-                fontSize: 13,
-                height: 1.35,
+              style: AppTypography.supporting.copyWith(
+                color: StyleConstants.mutedInkColor,
               ),
             ),
           ),
@@ -176,9 +163,9 @@ class _FirstLaunchSetupSheetState extends State<FirstLaunchSetupSheet> {
             title: regionPreferenceTitle(context, _selectedWorldview),
             onTap: _showRegionPicker,
             minHeight: _setupTileMinHeight,
-            trailing: const Icon(
+            trailing: Icon(
               Icons.keyboard_arrow_right,
-              color: Color(0x99FFFFFF),
+              color: StyleConstants.mutedInkColor,
             ),
           ),
           const SizedBox(height: 2),
@@ -207,10 +194,8 @@ class _SectionTitle extends StatelessWidget {
       padding: const EdgeInsets.only(bottom: 8, top: 4),
       child: Text(
         text,
-        style: const TextStyle(
-          color: Colors.white,
-          fontSize: 15,
-          fontWeight: FontWeight.w600,
+        style: AppTypography.cardTitle.copyWith(
+          color: StyleConstants.deepGreen,
         ),
       ),
     );
@@ -242,24 +227,21 @@ class _PrivacyAgreementTile extends StatelessWidget {
             padding: EdgeInsets.zero,
             minimumSize: Size.zero,
             tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-            foregroundColor: StyleConstants.defaultColor,
+            foregroundColor: StyleConstants.deepGreen,
           ),
           child: Text(
             context.tr("privacy.view_policy"),
-            style: TextStyle(
-              fontSize: 13,
+            style: AppTypography.supporting.copyWith(
               fontWeight: FontWeight.w600,
               decoration: TextDecoration.underline,
-              decorationColor: StyleConstants.defaultColor,
+              decorationColor: StyleConstants.deepGreen,
             ),
           ),
         ),
       ),
-      trailing: Checkbox(
+      trailing: AppCheckbox(
         value: accepted,
-        onChanged: (value) => onChanged(value ?? false),
-        activeColor: StyleConstants.defaultColor,
-        checkColor: Colors.black,
+        onChanged: onChanged,
       ),
     );
   }

--- a/app/lib/common/component/app_button.dart
+++ b/app/lib/common/component/app_button.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/material.dart';
+import 'package:memolanes/constants/app_typography.dart';
+import 'package:memolanes/constants/style_constants.dart';
+
+enum AppButtonVariant {
+  primary,
+  secondary,
+  tonal,
+  dangerTonal,
+  danger,
+}
+
+enum AppButtonSize { compact, regular, large }
+
+extension on AppButtonVariant {
+  Color get backgroundColor => switch (this) {
+        AppButtonVariant.primary => StyleConstants.primaryActionColor,
+        AppButtonVariant.secondary => StyleConstants.surfaceColor,
+        AppButtonVariant.tonal => StyleConstants.selectedSurfaceColor,
+        AppButtonVariant.dangerTonal => StyleConstants.dangerSurfaceColor,
+        AppButtonVariant.danger => StyleConstants.dangerColor,
+      };
+
+  Color get foregroundColor => switch (this) {
+        AppButtonVariant.primary => StyleConstants.onPrimaryActionColor,
+        AppButtonVariant.danger => StyleConstants.onDangerColor,
+        AppButtonVariant.dangerTonal => StyleConstants.dangerInkColor,
+        AppButtonVariant.secondary => StyleConstants.isDarkMode
+            ? StyleConstants.inkColor
+            : StyleConstants.onPrimaryActionColor,
+        AppButtonVariant.tonal => StyleConstants.deepGreen,
+      };
+
+  BorderSide? get side => switch (this) {
+        AppButtonVariant.secondary =>
+          BorderSide(color: StyleConstants.lineColor),
+        _ => null,
+      };
+}
+
+class AppButton extends StatelessWidget {
+  const AppButton({
+    super.key,
+    required this.label,
+    required this.onPressed,
+    this.icon,
+    this.variant = AppButtonVariant.primary,
+    this.size = AppButtonSize.regular,
+    this.expand = false,
+    this.loading = false,
+    this.backgroundAlpha = 1,
+    this.borderRadius,
+    this.fontSize,
+  })  : assert(backgroundAlpha >= 0 && backgroundAlpha <= 1),
+        assert(borderRadius == null || borderRadius >= 0),
+        assert(fontSize == null || fontSize > 0);
+
+  final String label;
+  final VoidCallback? onPressed;
+  final IconData? icon;
+  final AppButtonVariant variant;
+  final AppButtonSize size;
+  final bool expand;
+  final bool loading;
+  final double backgroundAlpha;
+  final double? borderRadius;
+  final double? fontSize;
+
+  @override
+  Widget build(BuildContext context) {
+    final height = switch (size) {
+      AppButtonSize.compact => 38.0,
+      AppButtonSize.regular => 44.0,
+      AppButtonSize.large => 52.0,
+    };
+    final radius = borderRadius ??
+        switch (size) {
+          AppButtonSize.compact => 13.0,
+          AppButtonSize.regular => 14.0,
+          AppButtonSize.large => 24.0,
+        };
+    final typeStyle = switch (size) {
+      AppButtonSize.compact => AppTypography.compactButton,
+      AppButtonSize.regular => AppTypography.button,
+      AppButtonSize.large => AppTypography.largeButton,
+    };
+    final horizontalPadding = switch (size) {
+      AppButtonSize.compact => 10.0,
+      AppButtonSize.regular => 16.0,
+      AppButtonSize.large => 18.0,
+    };
+    final iconSize = switch (size) {
+      AppButtonSize.compact => 16.0,
+      AppButtonSize.regular => 18.0,
+      AppButtonSize.large => 20.0,
+    };
+    final style = FilledButton.styleFrom(
+      elevation: 0,
+      backgroundColor:
+          variant.backgroundColor.withValues(alpha: backgroundAlpha),
+      foregroundColor: variant.foregroundColor,
+      disabledBackgroundColor: StyleConstants.lineColor,
+      disabledForegroundColor: StyleConstants.subtleInkColor,
+      side: variant.side,
+      padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+      textStyle: typeStyle.copyWith(fontSize: fontSize),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(radius),
+      ),
+    );
+
+    final iconWidget = loading
+        ? SizedBox.square(
+            dimension: size == AppButtonSize.compact ? 15 : 17,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: variant.foregroundColor,
+            ),
+          )
+        : icon == null
+            ? null
+            : Icon(
+                icon,
+                size: iconSize,
+              );
+    final effectiveOnPressed = loading ? null : onPressed;
+    final button = iconWidget == null
+        ? FilledButton(
+            onPressed: effectiveOnPressed,
+            style: style,
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          )
+        : FilledButton.icon(
+            onPressed: effectiveOnPressed,
+            style: style,
+            icon: iconWidget,
+            label: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          );
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        minWidth: expand ? double.infinity : 0,
+        minHeight: height,
+      ),
+      child: button,
+    );
+  }
+}
+
+class AppIconButton extends StatelessWidget {
+  const AppIconButton({
+    super.key,
+    required this.icon,
+    required this.onPressed,
+    this.tooltip,
+    this.variant = AppButtonVariant.tonal,
+    this.size = 42,
+    this.backgroundAlpha = 1,
+  })  : assert(size > 0),
+        assert(backgroundAlpha >= 0 && backgroundAlpha <= 1);
+
+  final IconData icon;
+  final VoidCallback? onPressed;
+  final String? tooltip;
+  final AppButtonVariant variant;
+  final double size;
+  final double backgroundAlpha;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton.filled(
+      onPressed: onPressed,
+      tooltip: tooltip,
+      style: IconButton.styleFrom(
+        backgroundColor:
+            variant.backgroundColor.withValues(alpha: backgroundAlpha),
+        foregroundColor: variant.foregroundColor,
+        disabledBackgroundColor: StyleConstants.lineColor,
+        disabledForegroundColor: StyleConstants.subtleInkColor,
+        fixedSize: Size.square(size),
+        side: variant.side,
+      ),
+      icon: Icon(icon, size: size * 0.48),
+    );
+  }
+}

--- a/app/lib/common/component/app_checkbox.dart
+++ b/app/lib/common/component/app_checkbox.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:memolanes/constants/style_constants.dart';
+
+/// The shared compact checkbox used throughout the app.
+///
+/// Styling lives with the component while UI v2 remains dark-only. The final
+/// theme PR can move these roles into the app-level [CheckboxThemeData].
+class AppCheckbox extends StatelessWidget {
+  const AppCheckbox({
+    super.key,
+    required this.value,
+    required this.onChanged,
+  }) : _indicator = false;
+
+  /// A non-interactive checkbox whose state and semantics are owned by its
+  /// parent control, such as a selectable settings tile.
+  const AppCheckbox.indicator({
+    super.key,
+    required this.value,
+  })  : onChanged = null,
+        _indicator = true;
+
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+  final bool _indicator;
+
+  @override
+  Widget build(BuildContext context) {
+    final changeCallback = onChanged;
+
+    final checkbox = Checkbox(
+      value: value,
+      onChanged: _indicator
+          ? (_) {}
+          : changeCallback == null
+              ? null
+              : (next) {
+                  if (next != null) changeCallback(next);
+                },
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      visualDensity: const VisualDensity(horizontal: -4, vertical: -4),
+      fillColor: WidgetStateProperty.resolveWith(
+        (states) => states.contains(WidgetState.selected)
+            ? StyleConstants.primaryActionColor
+            : Colors.transparent,
+      ),
+      checkColor: StyleConstants.onPrimaryActionColor,
+      side: const BorderSide(color: StyleConstants.strongLineColor),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5)),
+    );
+
+    if (!_indicator) return checkbox;
+    return ExcludeSemantics(
+      child: IgnorePointer(child: checkbox),
+    );
+  }
+}

--- a/app/lib/common/component/app_dialog.dart
+++ b/app/lib/common/component/app_dialog.dart
@@ -1,0 +1,216 @@
+import 'package:flutter/material.dart';
+import 'package:memolanes/common/component/liquid_glass_surface.dart';
+import 'package:memolanes/constants/app_typography.dart';
+import 'package:memolanes/constants/style_constants.dart';
+
+enum AppDialogSurfaceStyle { solid, glass }
+
+class AppDialogSurface extends StatelessWidget {
+  const AppDialogSurface({
+    super.key,
+    required this.child,
+    this.style = AppDialogSurfaceStyle.solid,
+    this.borderRadius = const BorderRadius.all(Radius.circular(24)),
+    this.backgroundColor,
+    this.glassBackgroundAlpha = 0.84,
+    this.shadowAlpha = 0.18,
+    this.shadowBlurRadius = 32,
+    this.shadowSpreadRadius = -8,
+    this.shadowOffset = const Offset(0, 12),
+  })  : assert(glassBackgroundAlpha >= 0 && glassBackgroundAlpha <= 1),
+        assert(shadowAlpha >= 0 && shadowAlpha <= 1),
+        assert(shadowBlurRadius >= 0);
+
+  final Widget child;
+  final AppDialogSurfaceStyle style;
+  final BorderRadius borderRadius;
+  final Color? backgroundColor;
+  final double glassBackgroundAlpha;
+  final double shadowAlpha;
+  final double shadowBlurRadius;
+  final double shadowSpreadRadius;
+  final Offset shadowOffset;
+
+  @override
+  Widget build(BuildContext context) {
+    if (style == AppDialogSurfaceStyle.glass) {
+      return LiquidGlassSurface(
+        borderRadius: borderRadius,
+        backgroundAlpha: glassBackgroundAlpha,
+        borderAlpha: 0.72,
+        blurSigma: 32,
+        reflectionAlpha: 0.1,
+        shadowAlpha: shadowAlpha,
+        shadowBlurRadius: shadowBlurRadius,
+        shadowSpreadRadius: shadowSpreadRadius,
+        shadowOffset: shadowOffset,
+        child: Material(color: Colors.transparent, child: child),
+      );
+    }
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: backgroundColor ?? StyleConstants.canvasColor,
+        borderRadius: borderRadius,
+        border: Border.all(color: StyleConstants.lineColor),
+        boxShadow: [
+          BoxShadow(
+            color: StyleConstants.shadowColor.withValues(
+              alpha: shadowAlpha,
+            ),
+            blurRadius: shadowBlurRadius,
+            spreadRadius: shadowSpreadRadius,
+            offset: shadowOffset,
+          ),
+        ],
+      ),
+      child: ClipRRect(
+        borderRadius: borderRadius,
+        child: Material(color: Colors.transparent, child: child),
+      ),
+    );
+  }
+}
+
+class AppDialogCard extends StatelessWidget {
+  const AppDialogCard({
+    super.key,
+    required this.child,
+    this.title,
+    this.subtitle,
+    this.leading,
+    this.actions,
+    this.showHeader = true,
+    this.surfaceStyle = AppDialogSurfaceStyle.solid,
+    this.maxHeightFactor = 0.78,
+    this.contentPadding = const EdgeInsets.fromLTRB(20, 12, 20, 18),
+    this.backgroundColor,
+  }) : assert(maxHeightFactor > 0 && maxHeightFactor <= 1);
+
+  final Widget child;
+  final String? title;
+  final String? subtitle;
+  final Widget? leading;
+  final Widget? actions;
+  final bool showHeader;
+  final AppDialogSurfaceStyle surfaceStyle;
+  final double maxHeightFactor;
+  final EdgeInsetsGeometry contentPadding;
+  final Color? backgroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.sizeOf(context).height * maxHeightFactor,
+      ),
+      child: AppDialogSurface(
+        style: surfaceStyle,
+        backgroundColor: backgroundColor,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (showHeader && title != null) ...[
+              const SizedBox(height: 14),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: Row(
+                  children: [
+                    SizedBox(width: 44, child: leading),
+                    Expanded(
+                      child: Text(
+                        title!,
+                        style: AppTypography.surfaceTitle.copyWith(
+                          color: StyleConstants.deepGreen,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                    const SizedBox(width: 44),
+                  ],
+                ),
+              ),
+              if (subtitle != null) ...[
+                const SizedBox(height: 6),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: Text(
+                    subtitle!,
+                    style: AppTypography.supporting.copyWith(
+                      color: StyleConstants.mutedInkColor,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              ],
+            ] else
+              const SizedBox(height: 8),
+            Flexible(
+              child: SingleChildScrollView(
+                padding: contentPadding,
+                child: child,
+              ),
+            ),
+            if (actions != null)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
+                child: actions!,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class AppDialogActions extends StatelessWidget {
+  const AppDialogActions({
+    super.key,
+    required this.children,
+    this.spacing = 10,
+  }) : assert(spacing >= 0);
+
+  final List<Widget> children;
+  final double spacing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        for (var i = 0; i < children.length; i++) ...[
+          if (i > 0) SizedBox(width: spacing),
+          Expanded(child: children[i]),
+        ],
+      ],
+    );
+  }
+}
+
+Future<T?> showAppDialog<T>(
+  BuildContext context, {
+  required Widget child,
+  bool barrierDismissible = true,
+  Color? barrierColor,
+  double maxWidth = 420,
+  EdgeInsets insetPadding =
+      const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+}) {
+  assert(maxWidth > 0);
+  return showDialog<T>(
+    context: context,
+    barrierDismissible: barrierDismissible,
+    barrierColor: barrierColor ??
+        StyleConstants.shadowColor.withValues(
+          alpha: StyleConstants.isDarkMode ? 0.58 : 0.22,
+        ),
+    builder: (dialogContext) => Dialog(
+      elevation: 0,
+      backgroundColor: Colors.transparent,
+      insetPadding: insetPadding,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: maxWidth),
+        child: SizedBox(width: double.infinity, child: child),
+      ),
+    ),
+  );
+}

--- a/app/lib/common/component/app_option_tile.dart
+++ b/app/lib/common/component/app_option_tile.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:memolanes/common/component/app_checkbox.dart';
+import 'package:memolanes/constants/app_typography.dart';
+import 'package:memolanes/constants/style_constants.dart';
+
+enum AppOptionTileTrailing { chevron, selection }
+
+class AppOptionTile extends StatelessWidget {
+  const AppOptionTile({
+    super.key,
+    required this.title,
+    required this.onTap,
+    this.icon,
+    this.iconWidget,
+    this.subtitle,
+    this.selected = false,
+    this.trailing = AppOptionTileTrailing.chevron,
+    this.backgroundAlpha = 0.76,
+  })  : assert(icon == null || iconWidget == null),
+        assert(backgroundAlpha >= 0 && backgroundAlpha <= 1),
+        assert(!selected || trailing == AppOptionTileTrailing.selection);
+
+  final String title;
+  final VoidCallback onTap;
+  final IconData? icon;
+  final Widget? iconWidget;
+  final String? subtitle;
+  final bool selected;
+  final AppOptionTileTrailing trailing;
+  final double backgroundAlpha;
+
+  Widget _buildTrailing() {
+    return switch (trailing) {
+      AppOptionTileTrailing.chevron => Icon(
+          Icons.chevron_right_rounded,
+          color: StyleConstants.mutedInkColor,
+          size: 22,
+        ),
+      AppOptionTileTrailing.selection => AppCheckbox.indicator(
+          value: selected,
+        ),
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      selected: trailing == AppOptionTileTrailing.selection ? selected : null,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(14),
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 170),
+            curve: Curves.easeOutCubic,
+            constraints: const BoxConstraints(minHeight: 58),
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            decoration: BoxDecoration(
+              color: selected
+                  ? StyleConstants.softGreen.withValues(alpha: 0.88)
+                  : StyleConstants.surfaceColor
+                      .withValues(alpha: backgroundAlpha),
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(
+                color: selected
+                    ? StyleConstants.primaryGreen
+                    : StyleConstants.lineColor,
+                width: selected ? 1.4 : 1,
+              ),
+            ),
+            child: Row(
+              children: [
+                if (icon != null || iconWidget != null) ...[
+                  AnimatedContainer(
+                    duration: const Duration(milliseconds: 170),
+                    width: 36,
+                    height: 36,
+                    decoration: BoxDecoration(
+                      color: selected
+                          ? StyleConstants.primaryGreen.withValues(alpha: 0.34)
+                          : StyleConstants.softGreen,
+                      borderRadius: BorderRadius.circular(11),
+                    ),
+                    alignment: Alignment.center,
+                    child: iconWidget ??
+                        Icon(
+                          icon,
+                          color: StyleConstants.deepGreen,
+                          size: 20,
+                        ),
+                  ),
+                  const SizedBox(width: 12),
+                ],
+                Expanded(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: AppTypography.itemTitle.copyWith(
+                          color: StyleConstants.inkColor,
+                        ),
+                      ),
+                      if (subtitle != null) ...[
+                        const SizedBox(height: 3),
+                        Text(
+                          subtitle!,
+                          maxLines: 3,
+                          overflow: TextOverflow.ellipsis,
+                          style: AppTypography.caption.copyWith(
+                            color: StyleConstants.mutedInkColor,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 10),
+                _buildTrailing(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/common/component/basic_bottom_sheet.dart
+++ b/app/lib/common/component/basic_bottom_sheet.dart
@@ -1,182 +1,44 @@
 import 'package:flutter/material.dart';
-import 'package:memolanes/common/component/cards/line_painter.dart';
-
-class BasicBottomSheet extends StatelessWidget {
-  const BasicBottomSheet({
-    super.key,
-    required this.child,
-    this.title,
-    this.actions,
-    this.leading,
-    this.showHandle = true,
-    this.showTitle = true,
-    this.maxHeightFactor,
-    this.contentPadding = EdgeInsets.zero,
-    this.backgroundColor = Colors.black,
-  });
-
-  final Widget child;
-  final String? title;
-  final Widget? actions;
-  final Widget? leading;
-  final bool showHandle;
-  final bool showTitle;
-  final double? maxHeightFactor;
-  final EdgeInsetsGeometry contentPadding;
-  final Color backgroundColor;
-
-  @override
-  Widget build(BuildContext context) {
-    final content = Container(
-      constraints: maxHeightFactor == null
-          ? null
-          : BoxConstraints(
-              maxHeight: MediaQuery.of(context).size.height * maxHeightFactor!,
-            ),
-      decoration: BoxDecoration(
-        color: backgroundColor,
-        borderRadius: const BorderRadius.only(
-          topLeft: Radius.circular(16.0),
-          topRight: Radius.circular(16.0),
-        ),
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 12.0),
-            child: Offstage(
-              offstage: !showHandle,
-              child: Center(
-                child: CustomPaint(
-                  size: const Size(40.0, 4.0),
-                  painter: LinePainter(
-                    color: const Color(0xFFB5B5B5),
-                  ),
-                ),
-              ),
-            ),
-          ),
-          if (showTitle && title != null)
-            Padding(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
-              child: Row(
-                children: [
-                  leading ?? const SizedBox(width: 48),
-                  Expanded(
-                    child: Text(
-                      title!,
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 18,
-                        fontWeight: FontWeight.w600,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                  const SizedBox(width: 48),
-                ],
-              ),
-            ),
-          Flexible(
-            child: SingleChildScrollView(
-              padding: contentPadding,
-              child: child,
-            ),
-          ),
-          if (actions != null) actions!,
-        ],
-      ),
-    );
-
-    return content;
-  }
-}
+import 'package:memolanes/common/component/app_dialog.dart';
+import 'package:memolanes/constants/style_constants.dart';
 
 Future<T?> showBasicBottomSheet<T>(
   BuildContext context, {
   required Widget child,
   String? title,
   Widget? actions,
-  Widget? leading,
-  bool showHandle = true,
   bool showTitle = true,
   double? maxHeightFactor,
   EdgeInsetsGeometry contentPadding = EdgeInsets.zero,
   Color? barrierColor,
-  Color backgroundColor = Colors.black,
+  Color? backgroundColor,
 }) {
-  return showModalBottomSheet<T>(
-    context: context,
-    backgroundColor: Colors.transparent,
-    barrierColor: barrierColor,
-    isScrollControlled: true,
-    isDismissible: true,
-    builder: (context) {
-      return BasicBottomSheet(
-        title: title,
-        actions: actions,
-        leading: leading,
-        showHandle: showHandle,
-        showTitle: showTitle,
-        maxHeightFactor: maxHeightFactor,
-        contentPadding: contentPadding,
-        backgroundColor: backgroundColor,
-        child: child,
-      );
-    },
-  );
-}
-
-void showBasicCard(
-  BuildContext context, {
-  required Widget child,
-  bool showHandle = true,
-}) {
-  showBasicBottomSheet<void>(
+  return showAppDialog<T>(
     context,
-    showHandle: showHandle,
-    showTitle: false,
-    child: child,
+    barrierColor: barrierColor,
+    maxWidth: 440,
+    child: AppDialogCard(
+      title: title,
+      showHeader: showTitle && title != null,
+      maxHeightFactor: maxHeightFactor ?? 0.78,
+      contentPadding: contentPadding,
+      backgroundColor: backgroundColor ?? StyleConstants.canvasColor,
+      actions: actions,
+      child: child,
+    ),
   );
 }
 
-Future<T?> showBasicCardWithResult<T>(
+Future<T?> showBasicCard<T>(
   BuildContext context, {
-  required String title,
   required Widget child,
-  String? primaryButtonText,
-  VoidCallback? onPrimaryPressed,
-  bool showHandle = true,
-  bool showLeading = true,
+  String? title,
 }) {
   return showBasicBottomSheet<T>(
     context,
     title: title,
-    showHandle: showHandle,
-    showTitle: showLeading,
-    maxHeightFactor: 0.75,
-    leading: IconButton(
-      icon: const Icon(Icons.arrow_back_ios, color: Colors.white),
-      onPressed: () => Navigator.of(context).pop(),
-    ),
-    actions: primaryButtonText != null && onPrimaryPressed != null
-        ? Padding(
-            padding: const EdgeInsets.fromLTRB(24, 16, 24, 24),
-            child: SizedBox(
-              width: double.infinity,
-              child: FilledButton(
-                onPressed: onPrimaryPressed,
-                style: FilledButton.styleFrom(
-                  backgroundColor: const Color(0xFF007AFF),
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                ),
-                child: Text(primaryButtonText),
-              ),
-            ),
-          )
-        : null,
+    showTitle: title != null,
+    contentPadding: EdgeInsets.fromLTRB(12, title == null ? 4 : 12, 12, 12),
     child: child,
   );
 }

--- a/app/lib/common/component/common_dialog.dart
+++ b/app/lib/common/component/common_dialog.dart
@@ -3,91 +3,91 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:memolanes/common/app_haptics.dart';
+import 'package:memolanes/common/component/app_button.dart';
+import 'package:memolanes/common/component/app_dialog.dart';
+import 'package:memolanes/constants/app_typography.dart';
+import 'package:memolanes/constants/style_constants.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 class DialogButton {
+  const DialogButton({
+    required this.text,
+    required this.onPressed,
+    this.variant = AppButtonVariant.primary,
+  });
+
   final String text;
   final VoidCallback onPressed;
-  final Color backgroundColor;
-  final Color textColor;
-
-  DialogButton({
-    required this.text,
-    VoidCallback? onPressed,
-    Color? backgroundColor,
-    Color? textColor,
-  })  : backgroundColor = backgroundColor ?? const Color(0xFFB4EC51),
-        textColor = textColor ?? Colors.black,
-        onPressed = onPressed ?? (() => {});
+  final AppButtonVariant variant;
 }
 
 class CommonDialog extends StatelessWidget {
+  const CommonDialog({
+    super.key,
+    required this.title,
+    required this.content,
+    this.buttons = const [],
+    this.markdown = false,
+  });
+
   final String title;
   final String content;
   final bool markdown;
   final List<DialogButton> buttons;
 
-  final DialogButton? customCancelButton;
-
-  CommonDialog(
-      {super.key,
-      required this.title,
-      required this.content,
-      List<DialogButton>? buttons,
-      bool? showCancel,
-      this.customCancelButton,
-      this.markdown = false})
-      : buttons = buttons ?? [];
-
   @override
   Widget build(BuildContext context) {
-    Widget messageBody = switch (markdown) {
+    final messageBody = switch (markdown) {
       false => ListBody(
           children: const LineSplitter()
               .convert(content)
-              .map((s) => Text(
-                    s,
-                  ))
-              .toList()),
+              .map(
+                (line) => Text(
+                  line,
+                  style: AppTypography.body.copyWith(
+                    color: StyleConstants.inkColor,
+                  ),
+                ),
+              )
+              .toList(),
+        ),
       true => MarkdownBody(
           data: content,
           onTapLink: (text, href, title) async {
-            if (href == null) {
-              return;
-            }
-            if (!await launchUrlString(href,
-                mode: LaunchMode.externalApplication)) {
+            if (href == null) return;
+            if (!await launchUrlString(
+              href,
+              mode: LaunchMode.externalApplication,
+            )) {
               throw Exception('Could not launch url: $href');
             }
           },
-        )
+        ),
     };
 
     return PointerInterceptor(
-        child: AlertDialog(
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(24),
-            ),
-            title: Text(
-              title,
-            ),
-            content: SingleChildScrollView(
-              child: messageBody,
-            ),
-            actionsPadding: const EdgeInsets.fromLTRB(24, 0, 24, 16),
-            actions: buttons.map((button) {
-              return FilledButton(
-                onPressed: () {
-                  AppHaptics.selection();
-                  button.onPressed();
-                },
-                style: FilledButton.styleFrom(
-                  backgroundColor: button.backgroundColor,
-                  foregroundColor: button.textColor,
-                ),
-                child: Text(button.text),
-              );
-            }).toList()));
+      child: AppDialogCard(
+        title: title,
+        maxHeightFactor: 0.78,
+        contentPadding: const EdgeInsets.fromLTRB(20, 14, 20, 18),
+        actions: buttons.isEmpty
+            ? null
+            : AppDialogActions(
+                children: [
+                  for (final button in buttons)
+                    AppButton(
+                      label: button.text,
+                      variant: button.variant,
+                      onPressed: () {
+                        AppHaptics.selection();
+                        button.onPressed();
+                      },
+                    ),
+                ],
+              ),
+        child: messageBody,
+      ),
+    );
   }
 }

--- a/app/lib/common/component/common_export.dart
+++ b/app/lib/common/component/common_export.dart
@@ -3,16 +3,18 @@ import 'dart:io';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_file_saver/flutter_file_saver.dart';
+import 'package:memolanes/common/component/app_button.dart';
+import 'package:memolanes/common/component/app_dialog.dart';
+import 'package:memolanes/common/component/app_option_tile.dart';
 import 'package:memolanes/common/component/basic_bottom_sheet.dart';
 import 'package:memolanes/common/loading_manager.dart';
 import 'package:memolanes/common/log.dart';
 import 'package:memolanes/common/utils.dart';
+import 'package:memolanes/constants/app_typography.dart';
 import 'package:memolanes/constants/style_constants.dart';
 import 'package:memolanes/src/rust/api/api.dart' as api;
 import 'package:path/path.dart' as p;
 import 'package:share_plus/share_plus.dart';
-
-const Color _exportActionSheetBackgroundColor = Color(0xFF242424);
 
 class CommonExportOption {
   const CommonExportOption({
@@ -96,10 +98,10 @@ Future<void> showCommonExportWithFormatPicker({
           (format) => format == defaultFormat,
           orElse: () => formats.first,
         );
-  final selectedFormat = await showDialog<CommonExportFormat>(
-    context: context,
+  final selectedFormat = await showAppDialog<CommonExportFormat>(
+    context,
     barrierDismissible: false,
-    builder: (_) => _ExportFormatDialog(
+    child: _ExportFormatDialog(
       title: title,
       formats: formats,
       initialFormat: initialFormat,
@@ -165,16 +167,9 @@ Future<bool> showCommonExport(
       return true;
     }
 
-    final action = await showBasicBottomSheet<_PreparedExportAction>(
+    final action = await showBasicCard<_PreparedExportAction>(
       context,
-      showTitle: false,
-      contentPadding: EdgeInsets.only(
-        left: 20.0,
-        right: 20.0,
-        bottom: 12.0 + MediaQuery.of(context).padding.bottom,
-      ),
-      barrierColor: const Color(0x99000000),
-      backgroundColor: _exportActionSheetBackgroundColor,
+      title: context.tr('common.export'),
       child: const _ExportActionSheetContent(),
     );
 
@@ -271,53 +266,13 @@ class _ExportFormatDialogState extends State<_ExportFormatDialog> {
     final option = format.option;
     final selected = _selectedFormat == format;
 
-    return Semantics(
-      button: true,
+    return AppOptionTile(
+      icon: option.icon,
+      title: option.title,
+      subtitle: option.description,
       selected: selected,
-      child: InkWell(
-        onTap: () => _selectFormat(format),
-        borderRadius: BorderRadius.circular(12.0),
-        child: Container(
-          padding: const EdgeInsets.symmetric(vertical: 10.0, horizontal: 4.0),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              Icon(
-                option.icon,
-                color: selected
-                    ? StyleConstants.defaultColor
-                    : const Color(0x99FFFFFF),
-              ),
-              const SizedBox(width: 12.0),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(option.title),
-                    const SizedBox(height: 2.0),
-                    Text(
-                      option.description,
-                      style: const TextStyle(
-                        color: Color(0x99FFFFFF),
-                        fontSize: 13.0,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(width: 12.0),
-              Icon(
-                selected
-                    ? Icons.radio_button_checked
-                    : Icons.radio_button_unchecked,
-                color: selected
-                    ? StyleConstants.defaultColor
-                    : const Color(0x99FFFFFF),
-              ),
-            ],
-          ),
-        ),
-      ),
+      trailing: AppOptionTileTrailing.selection,
+      onTap: () => _selectFormat(format),
     );
   }
 
@@ -332,22 +287,22 @@ class _ExportFormatDialogState extends State<_ExportFormatDialog> {
       margin: const EdgeInsets.only(top: 6.0),
       padding: const EdgeInsets.all(10.0),
       decoration: BoxDecoration(
-        color: const Color(0x22FFC107),
+        color: StyleConstants.warningSurfaceColor.withValues(alpha: 0.72),
         borderRadius: BorderRadius.circular(10.0),
       ),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Icon(
+          Icon(
             Icons.info_outline,
-            color: Color(0xFFFFC107),
+            color: StyleConstants.warningInkColor,
             size: 18.0,
           ),
           const SizedBox(width: 8.0),
           Expanded(
             child: Text(
               context.tr('data.export_data.lossy_format_warning'),
-              style: const TextStyle(fontSize: 13.0),
+              style: AppTypography.supporting,
             ),
           ),
         ],
@@ -357,13 +312,24 @@ class _ExportFormatDialogState extends State<_ExportFormatDialog> {
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
-      scrollable: true,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(24),
+    return AppDialogCard(
+      title: widget.title,
+      maxHeightFactor: 0.78,
+      contentPadding: const EdgeInsets.fromLTRB(20, 14, 20, 18),
+      actions: AppDialogActions(
+        children: [
+          AppButton(
+            label: context.tr('common.cancel'),
+            variant: AppButtonVariant.secondary,
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+          AppButton(
+            label: context.tr('common.export'),
+            onPressed: _submit,
+          ),
+        ],
       ),
-      title: Text(widget.title),
-      content: AnimatedSize(
+      child: AnimatedSize(
         duration: const Duration(milliseconds: 180),
         curve: Curves.easeOut,
         alignment: Alignment.topCenter,
@@ -376,34 +342,21 @@ class _ExportFormatDialogState extends State<_ExportFormatDialog> {
                 alignment: AlignmentDirectional.centerStart,
                 child: Text(
                   context.tr('data.export_data.format_section_title'),
-                  style: const TextStyle(
-                    color: Color(0x99FFFFFF),
-                    fontSize: 13.0,
+                  style: AppTypography.sectionLabel.copyWith(
+                    color: StyleConstants.mutedInkColor,
                   ),
                 ),
               ),
               const SizedBox(height: 6.0),
-              for (final format in widget.formats) _buildFormatOption(format),
+              for (var i = 0; i < widget.formats.length; i++) ...[
+                _buildFormatOption(widget.formats[i]),
+                if (i < widget.formats.length - 1) const SizedBox(height: 8),
+              ],
               _buildLossyWarning(),
             ],
           ),
         ),
       ),
-      actionsPadding: const EdgeInsets.fromLTRB(24, 0, 24, 16),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.of(context).pop(),
-          child: Text(context.tr('common.cancel')),
-        ),
-        FilledButton(
-          onPressed: _submit,
-          style: FilledButton.styleFrom(
-            backgroundColor: StyleConstants.defaultColor,
-            foregroundColor: Colors.black,
-          ),
-          child: Text(context.tr('common.export')),
-        ),
-      ],
     );
   }
 }
@@ -413,70 +366,21 @@ enum _PreparedExportAction { save, share }
 class _ExportActionSheetContent extends StatelessWidget {
   const _ExportActionSheetContent();
 
-  Widget _buildActionButton({
-    required BuildContext context,
-    required IconData icon,
-    required String label,
-    required _PreparedExportAction action,
-  }) {
-    return InkWell(
-      onTap: () => Navigator.of(context).pop(action),
-      borderRadius: BorderRadius.circular(16.0),
-      child: SizedBox(
-        width: 96.0,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 10.0),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Container(
-                width: 56.0,
-                height: 56.0,
-                decoration: const BoxDecoration(
-                  color: Color(0x1AFFFFFF),
-                  shape: BoxShape.circle,
-                ),
-                child: Icon(
-                  icon,
-                  color: StyleConstants.defaultColor,
-                  size: 26.0,
-                ),
-              ),
-              const SizedBox(height: 8.0),
-              Text(
-                label,
-                textAlign: TextAlign.center,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            _buildActionButton(
-              context: context,
-              icon: Icons.save_alt_outlined,
-              label: context.tr('common.save'),
-              action: _PreparedExportAction.save,
-            ),
-            _buildActionButton(
-              context: context,
-              icon: Icons.ios_share_outlined,
-              label: context.tr('common.share'),
-              action: _PreparedExportAction.share,
-            ),
-          ],
+        AppOptionTile(
+          icon: Icons.save_alt_outlined,
+          title: context.tr('common.save'),
+          onTap: () => Navigator.of(context).pop(_PreparedExportAction.save),
+        ),
+        const SizedBox(height: 8),
+        AppOptionTile(
+          icon: Icons.ios_share_outlined,
+          title: context.tr('common.share'),
+          onTap: () => Navigator.of(context).pop(_PreparedExportAction.share),
         ),
       ],
     );

--- a/app/lib/common/component/database_version_too_new_gate.dart
+++ b/app/lib/common/component/database_version_too_new_gate.dart
@@ -3,6 +3,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:memolanes/app_bootstrap.dart';
+import 'package:memolanes/common/component/app_button.dart';
+import 'package:memolanes/common/component/app_dialog.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 const _updateWebsiteUrl = 'https://app.memolanes.com/';
@@ -43,23 +45,24 @@ class _DatabaseVersionTooNewGateState extends State<DatabaseVersionTooNewGate> {
     await AppBootstrap.applyInitialLocale(context);
     if (!mounted) return;
 
-    await showDialog<void>(
-      context: context,
+    await showAppDialog<void>(
+      context,
       barrierDismissible: false,
-      builder: (dialogContext) => PopScope(
+      child: PopScope(
         canPop: false,
-        child: AlertDialog(
-          title: Text(dialogContext.tr('startup_error.title')),
-          content:
-              Text(dialogContext.tr('startup_error.database_version_too_new')),
-          actions: [
-            TextButton(
-              onPressed: _handleAction,
-              child: Text(dialogContext.tr(
-                _isIOS ? 'startup_error.update' : 'startup_error.exit',
-              )),
+        child: AppDialogCard(
+          title: context.tr('startup_error.title'),
+          actions: AppButton(
+            label: context.tr(
+              _isIOS ? 'startup_error.update' : 'startup_error.exit',
             ),
-          ],
+            onPressed: _handleAction,
+            expand: true,
+          ),
+          child: Text(
+            context.tr('startup_error.database_version_too_new'),
+            style: const TextStyle(height: 1.42),
+          ),
         ),
       ),
     );

--- a/app/lib/common/component/liquid_glass_surface.dart
+++ b/app/lib/common/component/liquid_glass_surface.dart
@@ -1,0 +1,176 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:memolanes/constants/style_constants.dart';
+
+/// An adaptive liquid-glass surface for controls displayed over the map.
+///
+/// Its light and dark treatments preserve map context while keeping controls
+/// readable. It is independent from the map's unexplored-area mask.
+class LiquidGlassSurface extends StatelessWidget {
+  const LiquidGlassSurface({
+    super.key,
+    required this.child,
+    this.borderRadius = const BorderRadius.all(Radius.circular(16)),
+    this.circular = false,
+    this.backgroundAlpha,
+    this.borderAlpha,
+    this.blurSigma = 28,
+    this.reflectionAlpha = 0.18,
+    this.reflectionColor,
+    this.secondaryReflectionColor,
+    this.shadowAlpha,
+    this.shadowBlurRadius = StyleConstants.mapOverlayShadowBlurRadius,
+    this.shadowSpreadRadius = StyleConstants.mapOverlayShadowSpreadRadius,
+    this.shadowOffset = StyleConstants.mapOverlayShadowOffset,
+    this.padding,
+  })  : assert(backgroundAlpha == null ||
+            backgroundAlpha >= 0 && backgroundAlpha <= 1),
+        assert(borderAlpha == null || borderAlpha >= 0 && borderAlpha <= 1),
+        assert(blurSigma >= 0),
+        assert(reflectionAlpha >= 0 && reflectionAlpha <= 1),
+        assert(shadowAlpha == null || shadowAlpha >= 0 && shadowAlpha <= 1),
+        assert(shadowBlurRadius >= 0);
+
+  final Widget child;
+  final BorderRadius borderRadius;
+  final bool circular;
+  final double? backgroundAlpha;
+  final double? borderAlpha;
+  final double blurSigma;
+  final double reflectionAlpha;
+  final Color? reflectionColor;
+  final Color? secondaryReflectionColor;
+  final double? shadowAlpha;
+  final double shadowBlurRadius;
+  final double shadowSpreadRadius;
+  final Offset shadowOffset;
+  final EdgeInsetsGeometry? padding;
+
+  BoxDecoration _decoration({
+    Color? color,
+    Border? border,
+    List<BoxShadow>? boxShadow,
+  }) {
+    return BoxDecoration(
+      color: color,
+      shape: circular ? BoxShape.circle : BoxShape.rectangle,
+      borderRadius: circular ? null : borderRadius,
+      border: border,
+      boxShadow: boxShadow,
+    );
+  }
+
+  Widget _clip(Widget child) {
+    if (circular) return ClipOval(child: child);
+    return ClipRRect(borderRadius: borderRadius, child: child);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveReflectionColor =
+        reflectionColor ?? StyleConstants.primaryGreen;
+    final effectiveSecondaryReflectionColor =
+        secondaryReflectionColor ?? StyleConstants.softGreen;
+    final effectiveShadowAlpha =
+        shadowAlpha ?? StyleConstants.mapOverlayShadowAlpha;
+    final effectiveBackgroundAlpha =
+        backgroundAlpha ?? (StyleConstants.isDarkMode ? 0.76 : 0.36);
+    final effectiveBorderAlpha =
+        borderAlpha ?? (StyleConstants.isDarkMode ? 0.46 : 0.62);
+
+    return DecoratedBox(
+      decoration: _decoration(
+        boxShadow: [
+          BoxShadow(
+            color: StyleConstants.shadowColor.withValues(
+              alpha: effectiveShadowAlpha,
+            ),
+            blurRadius: shadowBlurRadius,
+            spreadRadius: shadowSpreadRadius,
+            offset: shadowOffset,
+          ),
+          BoxShadow(
+            color: StyleConstants.glassHighlightColor.withValues(
+              alpha: StyleConstants.isDarkMode ? 0.1 : 0.28,
+            ),
+            blurRadius: 8,
+            spreadRadius: -5,
+            offset: const Offset(0, -2),
+          ),
+        ],
+      ),
+      child: _clip(
+        BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: blurSigma, sigmaY: blurSigma),
+          child: Stack(
+            fit: StackFit.passthrough,
+            children: [
+              Positioned.fill(
+                child: DecoratedBox(
+                  decoration: _decoration(
+                    color: StyleConstants.glassColor
+                        .withValues(alpha: effectiveBackgroundAlpha),
+                    border: Border.all(
+                      color: StyleConstants.glassBorderColor
+                          .withValues(alpha: effectiveBorderAlpha),
+                      width: 1.1,
+                    ),
+                  ),
+                ),
+              ),
+              if (reflectionAlpha > 0)
+                Positioned(
+                  right: -18,
+                  bottom: -20,
+                  width: 92,
+                  height: 58,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: RadialGradient(
+                        center: Alignment.bottomRight,
+                        radius: 1,
+                        colors: [
+                          effectiveReflectionColor.withValues(
+                            alpha: reflectionAlpha,
+                          ),
+                          effectiveSecondaryReflectionColor.withValues(
+                            alpha: reflectionAlpha * 0.36,
+                          ),
+                          Colors.transparent,
+                        ],
+                        stops: const [0, 0.5, 1],
+                      ),
+                    ),
+                  ),
+                ),
+              Positioned(
+                left: circular ? 10 : 14,
+                right: circular ? 10 : 14,
+                top: 1,
+                height: 1.2,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: [
+                        StyleConstants.glassHighlightColor.withValues(alpha: 0),
+                        StyleConstants.glassHighlightColor.withValues(
+                          alpha: StyleConstants.isDarkMode ? 0.32 : 0.88,
+                        ),
+                        StyleConstants.glassHighlightColor.withValues(alpha: 0),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              if (padding == null)
+                child
+              else
+                Padding(padding: padding!, child: child),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/common/component/permission_request_sheet.dart
+++ b/app/lib/common/component/permission_request_sheet.dart
@@ -3,15 +3,17 @@ import 'dart:io' show Platform;
 
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:memolanes/common/component/app_button.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:memolanes/common/component/setup_bottom_sheet.dart';
 import 'package:memolanes/common/log.dart';
 import 'package:memolanes/common/service/permission_service.dart';
 import 'package:memolanes/common/utils.dart';
+import 'package:memolanes/constants/app_typography.dart';
 import 'package:memolanes/constants/style_constants.dart';
 import 'package:permission_handler/permission_handler.dart';
 
-/// Shows the unified permission request bottom sheet (layout + copy only).
+/// Shows the unified permission request card (layout + copy only).
 ///
 /// Completes after the sheet is closed.
 Future<void> showPermissionRequestSheet(
@@ -19,14 +21,9 @@ Future<void> showPermissionRequestSheet(
 ) async {
   final permissions = PermissionService();
   unawaited(permissions.logPermissionState('sheet_open'));
-  await showModalBottomSheet<void>(
-    context: context,
-    backgroundColor: Colors.transparent,
-    isScrollControlled: true,
-    isDismissible: true,
-    builder: (context) {
-      return _PermissionRequestSheetContent();
-    },
+  await showSetupCard<void>(
+    context,
+    child: _PermissionRequestSheetContent(),
   );
   await permissions.logPermissionState('sheet_close');
 }
@@ -193,7 +190,11 @@ class _PermissionRequestSheetContentState
       title: context.tr("permission_sheet.title"),
       maxHeightFactor: 0.6,
       leading: IconButton(
-        icon: const Icon(Icons.arrow_back_ios, color: Colors.white, size: 20),
+        icon: Icon(
+          Icons.arrow_back_ios,
+          color: StyleConstants.deepGreen,
+          size: 20,
+        ),
         onPressed: _closeSheet,
         style: IconButton.styleFrom(
           padding: const EdgeInsets.all(8),
@@ -201,23 +202,14 @@ class _PermissionRequestSheetContentState
         ),
       ),
       actions: [
-        OutlinedButton(
+        AppButton(
+          label: context.tr("permission_sheet.skip"),
           onPressed: _onSkip,
-          style: OutlinedButton.styleFrom(
-            foregroundColor: Colors.white,
-            side: const BorderSide(color: Color(0xFFB5B5B5)),
-            padding: const EdgeInsets.symmetric(vertical: 12),
-          ),
-          child: Text(context.tr("permission_sheet.skip")),
+          variant: AppButtonVariant.secondary,
         ),
-        FilledButton(
+        AppButton(
+          label: context.tr("permission_sheet.enable_all"),
           onPressed: _onEnableAll,
-          style: FilledButton.styleFrom(
-            backgroundColor: StyleConstants.defaultColor,
-            foregroundColor: Colors.black,
-            padding: const EdgeInsets.symmetric(vertical: 12),
-          ),
-          child: Text(context.tr("permission_sheet.enable_all")),
         ),
       ],
       child: Column(
@@ -302,15 +294,14 @@ class _PermissionTile extends StatelessWidget {
                     padding: EdgeInsets.zero,
                     minimumSize: Size.zero,
                     tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    foregroundColor: StyleConstants.defaultColor,
+                    foregroundColor: StyleConstants.deepGreen,
                   ),
                   child: Text(
                     context.tr('permission_sheet.open_system_settings'),
-                    style: TextStyle(
-                      fontSize: 13,
+                    style: AppTypography.supporting.copyWith(
                       fontWeight: FontWeight.w600,
                       decoration: TextDecoration.underline,
-                      decorationColor: StyleConstants.defaultColor,
+                      decorationColor: StyleConstants.deepGreen,
                     ),
                   ),
                 ),
@@ -340,13 +331,13 @@ class _PermissionStatusIndicator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (isGranted) {
-      return const SizedBox(
+      return SizedBox(
         width: 52,
         height: 40,
         child: Center(
           child: Icon(
             Icons.check_circle,
-            color: StyleConstants.defaultColor,
+            color: StyleConstants.deepGreen,
             size: 24,
           ),
         ),
@@ -354,7 +345,7 @@ class _PermissionStatusIndicator extends StatelessWidget {
     }
 
     if (isDenied) {
-      const color = Color(0xFFFF6B6B);
+      final color = StyleConstants.dangerColor;
       return SizedBox(
         width: 52,
         height: 40,
@@ -371,7 +362,7 @@ class _PermissionStatusIndicator extends StatelessWidget {
                 border: Border.all(color: color.withValues(alpha: 0.75)),
               ),
               alignment: Alignment.center,
-              child: const Icon(
+              child: Icon(
                 Icons.close,
                 color: color,
                 size: 18,
@@ -397,19 +388,17 @@ class _PermissionStatusIndicator extends StatelessWidget {
             height: 30,
             padding: const EdgeInsets.symmetric(horizontal: 10),
             decoration: BoxDecoration(
-              color: StyleConstants.defaultColor.withValues(alpha: 0.12),
+              color: StyleConstants.deepGreen.withValues(alpha: 0.12),
               borderRadius: BorderRadius.circular(999),
               border: Border.all(
-                color: StyleConstants.defaultColor.withValues(alpha: 0.75),
+                color: StyleConstants.deepGreen.withValues(alpha: 0.75),
               ),
             ),
             alignment: Alignment.center,
             child: Text(
               label,
-              style: const TextStyle(
-                color: StyleConstants.defaultColor,
-                fontSize: 12,
-                fontWeight: FontWeight.w600,
+              style: AppTypography.label.copyWith(
+                color: StyleConstants.deepGreen,
               ),
             ),
           ),
@@ -433,10 +422,10 @@ class _PermissionInfoIcon extends StatelessWidget {
     Widget icon = GestureDetector(
       onTap: onTap,
       behavior: HitTestBehavior.opaque,
-      child: const Icon(
+      child: Icon(
         Icons.info_outline,
         size: 18.0,
-        color: Color(0x99FFFFFF),
+        color: StyleConstants.mutedInkColor,
       ),
     );
     if (tooltip != null && tooltip!.isNotEmpty) {

--- a/app/lib/common/component/setup_bottom_sheet.dart
+++ b/app/lib/common/component/setup_bottom_sheet.dart
@@ -1,6 +1,22 @@
 import 'package:flutter/material.dart';
-import 'package:memolanes/common/component/cards/line_painter.dart';
+import 'package:memolanes/common/component/app_dialog.dart';
+import 'package:memolanes/constants/app_typography.dart';
 import 'package:memolanes/constants/style_constants.dart';
+
+Future<T?> showSetupCard<T>(
+  BuildContext context, {
+  required Widget child,
+  bool barrierDismissible = true,
+  Color? barrierColor,
+}) {
+  return showAppDialog<T>(
+    context,
+    barrierDismissible: barrierDismissible,
+    barrierColor: barrierColor,
+    maxWidth: 440,
+    child: child,
+  );
+}
 
 class SetupBottomSheet extends StatelessWidget {
   const SetupBottomSheet({
@@ -25,70 +41,16 @@ class SetupBottomSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      constraints: BoxConstraints(
-        maxHeight: MediaQuery.of(context).size.height * maxHeightFactor,
-      ),
-      decoration: const BoxDecoration(
-        color: Colors.black,
-        borderRadius: BorderRadius.only(
-          topLeft: Radius.circular(16.0),
-          topRight: Radius.circular(16.0),
-        ),
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8.0),
-            child: Center(
-              child: CustomPaint(
-                size: const Size(40.0, 4.0),
-                painter: LinePainter(color: const Color(0xFFB5B5B5)),
-              ),
-            ),
-          ),
-          if (showTitle)
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 4.0, vertical: 0),
-              child: Row(
-                children: [
-                  leading ?? const SizedBox(width: 48),
-                  Expanded(
-                    child: Text(
-                      title,
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 16,
-                        fontWeight: FontWeight.w600,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                  const SizedBox(width: 48),
-                ],
-              ),
-            ),
-          Flexible(
-            child: SingleChildScrollView(
-              padding: contentPadding,
-              child: child,
-            ),
-          ),
-          if (actions.isNotEmpty)
-            Padding(
-              padding: const EdgeInsets.fromLTRB(20, 10, 20, 20),
-              child: Row(
-                children: [
-                  for (var i = 0; i < actions.length; i++) ...[
-                    if (i > 0) const SizedBox(width: 12),
-                    Expanded(child: actions[i]),
-                  ],
-                ],
-              ),
-            ),
-        ],
-      ),
+    return AppDialogCard(
+      title: title,
+      leading: leading,
+      showHeader: showTitle,
+      maxHeightFactor: maxHeightFactor,
+      contentPadding: contentPadding,
+      actions: actions.isEmpty
+          ? null
+          : AppDialogActions(spacing: 10, children: actions),
+      child: child,
     );
   }
 }
@@ -127,19 +89,34 @@ class SetupTile extends StatelessWidget {
           minHeight == null ? null : BoxConstraints(minHeight: minHeight!),
       padding: contentPadding,
       decoration: BoxDecoration(
-        color: const Color(0x1AFFFFFF),
-        borderRadius: BorderRadius.circular(10),
-        border: selected
-            ? Border.all(color: StyleConstants.defaultColor)
-            : Border.all(color: Colors.transparent),
+        color: selected
+            ? StyleConstants.softGreen.withValues(alpha: 0.82)
+            : StyleConstants.surfaceColor,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(
+          color:
+              selected ? StyleConstants.primaryGreen : StyleConstants.lineColor,
+          width: selected ? 1.4 : 1,
+        ),
       ),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          Icon(
-            icon,
-            color: StyleConstants.defaultColor,
-            size: 22,
+          Container(
+            width: 34,
+            height: 34,
+            decoration: BoxDecoration(
+              color: selected
+                  ? StyleConstants.primaryGreen.withValues(alpha: 0.32)
+                  : StyleConstants.softGreen,
+              borderRadius: BorderRadius.circular(10),
+            ),
+            alignment: Alignment.center,
+            child: Icon(
+              icon,
+              color: StyleConstants.deepGreen,
+              size: 20,
+            ),
           ),
           const SizedBox(width: 12),
           Expanded(
@@ -153,10 +130,8 @@ class SetupTile extends StatelessWidget {
                     Flexible(
                       child: Text(
                         title,
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 15,
-                          fontWeight: FontWeight.w500,
+                        style: AppTypography.cardTitle.copyWith(
+                          color: StyleConstants.inkColor,
                         ),
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis,
@@ -173,9 +148,8 @@ class SetupTile extends StatelessWidget {
                     padding: const EdgeInsets.only(top: 2),
                     child: Text(
                       subtitle!,
-                      style: const TextStyle(
-                        color: Color(0xFFB0B0B0),
-                        fontSize: 12,
+                      style: AppTypography.caption.copyWith(
+                        color: StyleConstants.mutedInkColor,
                       ),
                     ),
                   ),
@@ -192,7 +166,7 @@ class SetupTile extends StatelessWidget {
       padding: const EdgeInsets.only(bottom: 10),
       child: InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(10),
+        borderRadius: BorderRadius.circular(14),
         child: tile,
       ),
     );

--- a/app/lib/common/recording_health_service.dart
+++ b/app/lib/common/recording_health_service.dart
@@ -4,6 +4,8 @@ import 'package:device_info_plus/device_info_plus.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:memolanes/common/component/app_button.dart';
+import 'package:memolanes/common/component/app_dialog.dart';
 import 'package:memolanes/common/component/common_dialog.dart';
 import 'package:memolanes/common/gps_manager.dart';
 import 'package:memolanes/common/log.dart';
@@ -118,10 +120,10 @@ class _RecordingHealthAlert {
       final helpUrl = await _helpUrl();
       if (!context.mounted) return;
 
-      final disableHeartbeatDetection = await showDialog<bool>(
-        context: context,
+      final disableHeartbeatDetection = await showAppDialog<bool>(
+        context,
         barrierDismissible: false,
-        builder: (dialogContext) => CommonDialog(
+        child: CommonDialog(
           title: context.tr('recording_health.interruption_detected'),
           content: '${context.tr('recording_health.freeze_warning')}\n\n'
               '**[${context.tr('recording_health.view_help')} ↗]($helpUrl)**',
@@ -129,13 +131,12 @@ class _RecordingHealthAlert {
           buttons: [
             DialogButton(
               text: context.tr('recording_health.dont_remind_again'),
-              onPressed: () => Navigator.of(dialogContext).pop(true),
-              backgroundColor: Colors.red,
-              textColor: Colors.white,
+              variant: AppButtonVariant.danger,
+              onPressed: () => Navigator.of(context).pop(true),
             ),
             DialogButton(
               text: context.tr('common.ok'),
-              onPressed: () => Navigator.of(dialogContext).pop(false),
+              onPressed: () => Navigator.of(context).pop(false),
             ),
           ],
         ),

--- a/app/lib/common/region_preference.dart
+++ b/app/lib/common/region_preference.dart
@@ -1,9 +1,9 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
+import 'package:memolanes/common/component/app_option_tile.dart';
 import 'package:memolanes/common/component/setup_bottom_sheet.dart';
 import 'package:memolanes/common/mmkv_util.dart';
-import 'package:memolanes/constants/style_constants.dart';
 import 'package:memolanes/src/rust/api/achievement.dart' as achievement;
 import 'package:mutex/mutex.dart';
 
@@ -104,13 +104,9 @@ Future<achievement.Worldview?> showWorldviewPicker(
   BuildContext context, {
   required achievement.Worldview selectedWorldview,
 }) {
-  return showModalBottomSheet<achievement.Worldview>(
-    context: context,
-    backgroundColor: Colors.transparent,
-    isScrollControlled: true,
-    builder: (context) {
-      return _RegionPickerSheet(selectedWorldview: selectedWorldview);
-    },
+  return showSetupCard<achievement.Worldview>(
+    context,
+    child: _RegionPickerSheet(selectedWorldview: selectedWorldview),
   );
 }
 
@@ -122,29 +118,25 @@ class _RegionPickerSheet extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SetupBottomSheet(
-      title: '',
-      showTitle: false,
+      title: context.tr("privacy.region_title"),
       maxHeightFactor: 0.55,
-      contentPadding: const EdgeInsets.fromLTRB(20, 4, 20, 10),
+      contentPadding: const EdgeInsets.fromLTRB(20, 14, 20, 10),
       child: Column(
         children: [
-          for (final worldview in _worldviewDisplayOrder)
-            SetupTile(
-              icon: regionPreferenceIcon(worldview),
-              title: regionPreferenceTitle(context, worldview),
-              selected: worldview == selectedWorldview,
-              onTap: () => Navigator.of(context).pop(worldview),
-              contentPadding:
-                  const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
-              trailing: Icon(
-                worldview == selectedWorldview
-                    ? Icons.check_circle
-                    : Icons.circle_outlined,
-                color: worldview == selectedWorldview
-                    ? StyleConstants.defaultColor
-                    : const Color(0x99FFFFFF),
+          for (var i = 0; i < _worldviewDisplayOrder.length; i++) ...[
+            AppOptionTile(
+              icon: regionPreferenceIcon(_worldviewDisplayOrder[i]),
+              title: regionPreferenceTitle(
+                context,
+                _worldviewDisplayOrder[i],
               ),
+              selected: _worldviewDisplayOrder[i] == selectedWorldview,
+              trailing: AppOptionTileTrailing.selection,
+              onTap: () => Navigator.of(context).pop(_worldviewDisplayOrder[i]),
             ),
+            if (i < _worldviewDisplayOrder.length - 1)
+              const SizedBox(height: 8),
+          ],
         ],
       ),
     );

--- a/app/lib/common/utils.dart
+++ b/app/lib/common/utils.dart
@@ -1,6 +1,8 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:memolanes/common/component/app_dialog.dart';
 import 'package:memolanes/common/component/common_dialog.dart';
+import 'package:memolanes/common/component/app_button.dart';
 import 'package:memolanes/common/component/import_loading_page.dart';
 import 'package:memolanes/body/settings/mldx_import_page.dart';
 import 'package:memolanes/common/loading_manager.dart';
@@ -22,49 +24,51 @@ bool popCurrentRoute<T>(BuildContext context, [T? result]) {
 }
 
 Future<bool> showCommonDialog(BuildContext context, String message,
-    {hasCancel = false,
-    title,
-    confirmButtonText,
-    cancelButtonText,
-    confirmGroundColor,
-    confirmTextColor = Colors.black,
-    markdown = false}) async {
-  confirmButtonText = confirmButtonText ?? context.tr("common.ok");
-  cancelButtonText = cancelButtonText ?? context.tr("common.cancel");
-  title = title ?? context.tr("common.info");
-  confirmGroundColor = confirmGroundColor ?? StyleConstants.defaultColor;
+    {bool hasCancel = false,
+    String? title,
+    String? confirmButtonText,
+    String? cancelButtonText,
+    AppButtonVariant confirmVariant = AppButtonVariant.primary,
+    // Temporary compatibility for pages migrated in later UI v2 PRs.
+    Color? confirmGroundColor,
+    Color? confirmTextColor,
+    bool markdown = false}) async {
+  final resolvedConfirmButtonText =
+      confirmButtonText ?? context.tr("common.ok");
+  final resolvedCancelButtonText =
+      cancelButtonText ?? context.tr("common.cancel");
+  final dialogTitle = title ?? context.tr("common.info");
+  final effectiveConfirmVariant = confirmGroundColor == null ||
+          confirmGroundColor == StyleConstants.defaultColor
+      ? confirmVariant
+      : AppButtonVariant.danger;
   final List<DialogButton> allButtons = [
+    if (hasCancel)
+      DialogButton(
+        text: resolvedCancelButtonText,
+        variant: AppButtonVariant.secondary,
+        onPressed: () {
+          Navigator.of(context).pop(false);
+        },
+      ),
     DialogButton(
-      text: confirmButtonText,
+      text: resolvedConfirmButtonText,
+      variant: effectiveConfirmVariant,
       onPressed: () {
         Navigator.of(context).pop(true);
       },
-      backgroundColor: confirmGroundColor,
-      textColor: confirmTextColor,
     ),
-    if (hasCancel)
-      DialogButton(
-          text: cancelButtonText,
-          backgroundColor: confirmGroundColor == StyleConstants.defaultColor
-              ? Colors.grey
-              : StyleConstants.defaultColor,
-          onPressed: () {
-            Navigator.of(context).pop(false);
-          })
   ];
 
-  var result = await showDialog<bool>(
-    context: context,
+  final result = await showAppDialog<bool>(
+    context,
     barrierDismissible: false,
-    builder: (BuildContext context) {
-      return CommonDialog(
-        title: title,
-        content: message,
-        showCancel: hasCancel,
-        buttons: allButtons,
-        markdown: markdown,
-      );
-    },
+    child: CommonDialog(
+      title: dialogTitle,
+      content: message,
+      buttons: allButtons,
+      markdown: markdown,
+    ),
   );
   return result ?? false;
 }

--- a/app/lib/constants/app_typography.dart
+++ b/app/lib/constants/app_typography.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+
+/// Semantic typography used throughout MemoLanes.
+///
+/// The scale intentionally uses a small number of roles so Chinese and English
+/// copy keep the same hierarchy. Generic bilingual styles avoid letter spacing;
+/// tracking is reserved for short, Latin-only status badges.
+abstract final class AppTypography {
+  static const TextStyle pageTitle = TextStyle(
+    fontSize: 28,
+    fontWeight: FontWeight.w800,
+    height: 1.1,
+  );
+
+  static const TextStyle compactPageTitle = TextStyle(
+    fontSize: 24,
+    fontWeight: FontWeight.w800,
+    height: 1.1,
+  );
+
+  static const TextStyle metricTitle = TextStyle(
+    fontSize: 22,
+    fontWeight: FontWeight.w800,
+    height: 1.08,
+  );
+
+  static const TextStyle dataValue = TextStyle(
+    fontSize: 32,
+    fontWeight: FontWeight.w500,
+    height: 1.1,
+  );
+
+  static const TextStyle pickerValue = TextStyle(
+    fontSize: 20,
+    fontWeight: FontWeight.w600,
+    height: 1.2,
+  );
+
+  static const TextStyle surfaceTitle = TextStyle(
+    fontSize: 17,
+    fontWeight: FontWeight.w700,
+    height: 1.2,
+  );
+
+  static const TextStyle subpageTitle = TextStyle(
+    fontSize: 16,
+    fontWeight: FontWeight.w600,
+    height: 1.25,
+  );
+
+  static const TextStyle cardTitle = TextStyle(
+    fontSize: 15,
+    fontWeight: FontWeight.w600,
+    height: 1.3,
+  );
+
+  static const TextStyle itemTitle = TextStyle(
+    fontSize: 14,
+    fontWeight: FontWeight.w600,
+    height: 1.35,
+  );
+
+  static const TextStyle bodyLarge = TextStyle(
+    fontSize: 16,
+    fontWeight: FontWeight.w400,
+    height: 1.4,
+  );
+
+  static const TextStyle body = TextStyle(
+    fontSize: 14,
+    fontWeight: FontWeight.w400,
+    height: 1.42,
+  );
+
+  static const TextStyle supporting = TextStyle(
+    fontSize: 13,
+    fontWeight: FontWeight.w400,
+    height: 1.4,
+  );
+
+  static const TextStyle caption = TextStyle(
+    fontSize: 12,
+    fontWeight: FontWeight.w500,
+    height: 1.3,
+  );
+
+  static const TextStyle label = TextStyle(
+    fontSize: 12,
+    fontWeight: FontWeight.w600,
+    height: 1.2,
+  );
+
+  static const TextStyle micro = TextStyle(
+    fontSize: 11,
+    fontWeight: FontWeight.w600,
+    height: 1.2,
+  );
+
+  static const TextStyle sectionLabel = TextStyle(
+    fontSize: 13,
+    fontWeight: FontWeight.w600,
+    height: 1.2,
+  );
+
+  static const TextStyle button = TextStyle(
+    fontSize: 14,
+    fontWeight: FontWeight.w700,
+    height: 1.15,
+  );
+
+  static const TextStyle compactButton = TextStyle(
+    fontSize: 12,
+    fontWeight: FontWeight.w700,
+    height: 1.15,
+  );
+
+  static const TextStyle largeButton = TextStyle(
+    fontSize: 16,
+    fontWeight: FontWeight.w700,
+    height: 1.15,
+  );
+
+  static const TextStyle badge = TextStyle(
+    fontSize: 11,
+    fontWeight: FontWeight.w700,
+    height: 1.1,
+    letterSpacing: 0.2,
+  );
+
+  static const TextTheme textTheme = TextTheme(
+    displaySmall: pageTitle,
+    headlineSmall: metricTitle,
+    titleLarge: surfaceTitle,
+    titleMedium: cardTitle,
+    titleSmall: itemTitle,
+    bodyLarge: bodyLarge,
+    bodyMedium: body,
+    bodySmall: supporting,
+    labelLarge: button,
+    labelMedium: label,
+    labelSmall: micro,
+  );
+}

--- a/app/lib/constants/index.dart
+++ b/app/lib/constants/index.dart
@@ -1,1 +1,2 @@
+export 'app_typography.dart';
 export 'style_constants.dart';

--- a/app/lib/constants/style_constants.dart
+++ b/app/lib/constants/style_constants.dart
@@ -5,6 +5,48 @@ import 'package:memolanes/common/component/bottom_nav_bar.dart';
 class StyleConstants {
   StyleConstants._();
 
+  // Part 1 deliberately keeps the app dark-only. A later UI v2 PR will make
+  // these semantic roles adaptive and introduce the user-facing theme mode.
+  static const bool isDarkMode = true;
+
+  // Surface and content roles.
+  static const Color canvasColor = Color(0xFF0B100D);
+  static const Color surfaceColor = Color(0xFF171918);
+  static const Color elevatedSurfaceColor = Color(0xFF1C2620);
+  static const Color inkColor = Color(0xFFF1F5EF);
+  static const Color mutedInkColor = Color(0xFFA2ADA6);
+  static const Color subtleInkColor = Color(0xFF77837B);
+  static const Color lineColor = Color(0xFF2B3730);
+  static const Color strongLineColor = Color(0xFF44534A);
+  static const Color inverseInkColor = Color(0xFF10150F);
+  static const Color onStrongColor = Color(0xFFF8FBF6);
+  static const Color shadowColor = Color(0xFF000000);
+
+  // Translucent surfaces.
+  static const Color glassColor = Color(0xFF111814);
+  static const Color glassBorderColor = Color(0xFF718078);
+  static const Color glassHighlightColor = Color(0xFFE5F5E8);
+
+  // Brand, selection, and action roles.
+  static const Color primaryGreen = Color(0xFFB8EA72);
+  static const Color deepGreen = Color(0xFF8ACB55);
+  static const Color softGreen = Color(0xFF21331F);
+  static const Color journeyYellow = Color(0xFFFFD75A);
+  static const Color deepYellow = Color(0xFFF0C74B);
+  static const Color softYellow = Color(0xFF352F19);
+  static const Color primaryActionColor = primaryGreen;
+  static const Color onPrimaryActionColor = inverseInkColor;
+  static const Color selectedSurfaceColor = softGreen;
+
+  // Feedback roles.
+  static const Color warningColor = journeyYellow;
+  static const Color warningInkColor = deepYellow;
+  static const Color warningSurfaceColor = softYellow;
+  static const Color dangerColor = Color(0xFFFF6F7D);
+  static const Color dangerInkColor = Color(0xFFFF9AA4);
+  static const Color dangerSurfaceColor = Color(0xFF3A2026);
+  static const Color onDangerColor = inverseInkColor;
+
   // navBar
   // Visual bottom inset for the floating nav bar on gesture/home-indicator
   // devices. This intentionally differs from the raw safe-area value so iOS
@@ -54,7 +96,14 @@ class StyleConstants {
       navBarSafeAreaForContext(context) + mapPrimaryControlNavBarSpacing;
 
   // colors
-  static const Color defaultColor = Color(0xFFB4EC51);
+  // Compatibility alias for pages that have not migrated to semantic roles.
+  static const Color defaultColor = primaryGreen;
   static const Color loadingMaskColor = Color.fromRGBO(0, 0, 0, 0.35);
   static const double overlayFloatingRadius = 16.0;
+
+  // Shared elevation for glass controls displayed over the map.
+  static const double mapOverlayShadowAlpha = 0.42;
+  static const double mapOverlayShadowBlurRadius = 26;
+  static const double mapOverlayShadowSpreadRadius = -3;
+  static const Offset mapOverlayShadowOffset = Offset(0, 8);
 }

--- a/app/test/app_components_test.dart
+++ b/app/test/app_components_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memolanes/common/component/app_button.dart';
+import 'package:memolanes/common/component/app_dialog.dart';
+import 'package:memolanes/common/component/common_dialog.dart';
+
+void main() {
+  testWidgets('loading button cannot trigger duplicate actions',
+      (tester) async {
+    var pressCount = 0;
+
+    Widget buildButton({required bool loading}) {
+      return MaterialApp(
+        theme: ThemeData.dark(),
+        home: Scaffold(
+          body: Center(
+            child: AppButton(
+              label: 'Save',
+              loading: loading,
+              onPressed: () => pressCount++,
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildButton(loading: true));
+
+    final loadingButton = tester.widget<FilledButton>(
+      find.byType(FilledButton),
+    );
+    expect(loadingButton.onPressed, isNull);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    await tester.tap(find.text('Save'));
+    expect(pressCount, 0);
+
+    await tester.pumpWidget(buildButton(loading: false));
+    await tester.tap(find.text('Save'));
+    expect(pressCount, 1);
+  });
+
+  testWidgets('dialog card stays usable on a narrow viewport', (tester) async {
+    tester.view.physicalSize = const Size(320, 480);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(),
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: Center(
+              child: TextButton(
+                onPressed: () => showAppDialog<void>(
+                  context,
+                  child: AppDialogCard(
+                    title: 'A long but readable dialog title',
+                    actions: AppDialogActions(
+                      children: [
+                        AppButton(
+                          label: 'Cancel operation',
+                          variant: AppButtonVariant.secondary,
+                          onPressed: () => Navigator.of(context).pop(),
+                        ),
+                        AppButton(
+                          label: 'Confirm operation',
+                          onPressed: () => Navigator.of(context).pop(),
+                        ),
+                      ],
+                    ),
+                    child:
+                        Text(List.filled(30, 'Scrollable content').join('\n')),
+                  ),
+                ),
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(Dialog), findsOneWidget);
+    expect(find.textContaining('Scrollable content'), findsOneWidget);
+    expect(find.text('Cancel operation'), findsOneWidget);
+    expect(find.text('Confirm operation'), findsOneWidget);
+  });
+
+  testWidgets('common dialog returns the selected action', (tester) async {
+    bool? result;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(),
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: TextButton(
+              onPressed: () async {
+                result = await showAppDialog<bool>(
+                  context,
+                  barrierDismissible: false,
+                  child: CommonDialog(
+                    title: 'Delete item?',
+                    content: 'This action cannot be undone.',
+                    buttons: [
+                      DialogButton(
+                        text: 'Cancel',
+                        onPressed: () => Navigator.of(context).pop(false),
+                      ),
+                      DialogButton(
+                        text: 'Delete',
+                        variant: AppButtonVariant.danger,
+                        onPressed: () => Navigator.of(context).pop(true),
+                      ),
+                    ],
+                  ),
+                );
+              },
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    expect(find.text('Delete'), findsOneWidget);
+    tester
+        .widget<CommonDialog>(find.byType(CommonDialog))
+        .buttons
+        .last
+        .onPressed();
+    await tester.pumpAndSettle();
+
+    expect(result, isTrue);
+    expect(find.byType(Dialog), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

- introduce semantic typography and a fixed-dark semantic color foundation
- add shared buttons, checkboxes, dialog surfaces, option tiles, and liquid-glass surfaces
- migrate common dialogs, setup/permission/region flows, export dialogs, and the database-version gate to the shared components
- add focused widget coverage for loading buttons, narrow dialog layouts, and dialog results

## Scope boundaries

This PR intentionally keeps the application dark-only. It does not expose system/light/dark theme selection, and it does not include the shared MapBody architecture, map controls, time-machine changes, journey list/map/editor changes, settings or achievement redesigns, map fog configuration, or Android splash/theme changes.

Keeping theme selection out of this foundation PR avoids an intermediate state where only part of the application responds correctly to light mode. Existing unmigrated pages continue to use the compatibility accent and dialog parameters until their feature PRs land.

## Verification

- dart format check for all changed Dart files
- flutter analyze --no-pub
- flutter test (11 tests passed)
- git diff --check

## Follow-up

The remaining UI v2 PRs can build on these semantic roles and shared interaction components while keeping their feature-specific diffs focused.
